### PR TITLE
improve output to educate user about what is happening

### DIFF
--- a/workflow/colors.py
+++ b/workflow/colors.py
@@ -1,0 +1,19 @@
+"""See https://github.com/fabric/fabric/blob/master/fabric/colors.py
+"""
+
+def _wrap_with(code):
+
+    def inner(text, bold=False):
+        c = code
+        if bold:
+            c = "1;%s" % c
+        return "\033[%sm%s\033[0m" % (c, text)
+    return inner
+
+red = _wrap_with('31')
+green = _wrap_with('32')
+yellow = _wrap_with('33')
+blue = _wrap_with('34')
+magenta = _wrap_with('35')
+cyan = _wrap_with('36')
+white = _wrap_with('37')


### PR DESCRIPTION
use color. state what task is being executed. then show commands for a task execution. then state time of execution. for example, in the `serial/workflow.yaml` (which consists of two tasks), it should look something like this:

```
<green>data/reuters21578</green>
mkdir -p data/reuters21578
tar xzf data/reuters21578.tar.gz -C data/reuters21578
                                                                    0.12 s
```
