### PR TITLE
Implement --export

### DIFF
--- a/bin/workflow
+++ b/bin/workflow
@@ -17,8 +17,7 @@ parser = argparse.ArgumentParser(
 )
 
 # can only specify one of --force or --dry-run
-group = parser.add_argument_group(title="Workflow execution")
-group.add_argument(
+parser.add_argument(
     '-f', '--force',
     action="store_true",
     help=(
@@ -26,15 +25,22 @@ group.add_argument(
         "remove all `creates` targets in workflow without confirmation."
     ),
 )
-group.add_argument(
+parser.add_argument(
     '-d', '--dry-run',
     action="store_true",
-    help="Rerun entire workflow, regardless of task state.",
+    help=(
+        "Do not run workflow, just report which tasks woulc be run and how "
+        "long it would take."
+    ),
+)
+parser.add_argument(
+    '-e', '--export',
+    action="store_true",
+    help="Export shell script instead of running the workflow.",
 )
 
 # can only specify one of --clean or --force-clean
-group = parser.add_argument_group(title="Cleaning up")
-group.add_argument(
+parser.add_argument(
     '-c', '--clean',
     action="store_true",
     help="Confirm before removing all `creates` targets defined in workflow.",
@@ -45,4 +51,4 @@ args = parser.parse_args()
 if args.clean:
     clean(force=args.force)
 else:
-    execute(force=args.force, dry_run=args.dry_run)
+    execute(force=args.force, dry_run=args.dry_run, export=args.export)

--- a/bin/workflow
+++ b/bin/workflow
@@ -51,7 +51,7 @@ parser.add_argument(
 args = parser.parse_args()
 try:
     if args.clean:
-        clean(force=args.force)
+        clean(force=args.force, export=args.export)
     else:
         execute(force=args.force, dry_run=args.dry_run, export=args.export)
 except CommandLineException, e:

--- a/bin/workflow
+++ b/bin/workflow
@@ -10,6 +10,7 @@ import os
 import ConfigParser
 
 from workflow.commands import execute, clean
+from workflow.exceptions import CommandLineException
 
 # setup the option parser
 parser = argparse.ArgumentParser(
@@ -48,7 +49,11 @@ parser.add_argument(
 
 # parse arguemnts and run it
 args = parser.parse_args()
-if args.clean:
-    clean(force=args.force)
-else:
-    execute(force=args.force, dry_run=args.dry_run, export=args.export)
+try:
+    if args.clean:
+        clean(force=args.force)
+    else:
+        execute(force=args.force, dry_run=args.dry_run, export=args.export)
+except CommandLineException, e:
+    print(e)
+    sys.exit(1)

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -5,7 +5,7 @@ from distutils.util import strtobool
 from .parser import load_task_graph
 from . import colors
 
-def clean(force=False, pause=0.5):
+def clean(force=False, export=False, pause=0.5):
     """Remove all `creates` targets defined in workflow
     """
 
@@ -29,7 +29,7 @@ def clean(force=False, pause=0.5):
 
     # for every task in the task graph, remove the corresponding
     # `creates` targets
-    task_graph.clean()
+    task_graph.clean(export=export)
 
 def execute(force=False, dry_run=False, export=False):
     """Execute the task workflow.

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -29,6 +29,8 @@ def clean(force=False, export=False, pause=0.5):
 
     # for every task in the task graph, remove the corresponding
     # `creates` targets
+    if export:
+        print("cd %s" % task_graph.root_directory)
     task_graph.clean(export=export)
 
 def execute(force=False, dry_run=False, export=False):
@@ -53,7 +55,9 @@ def execute(force=False, dry_run=False, export=False):
     # report the minimum amount of time this will take to execute and
     # execute all tasks
     if out_of_sync_tasks:
-        if not export:
+        if export:
+            print("cd %s" % task_graph.root_directory)
+        else:
             print(task_graph.duration_message(out_of_sync_tasks))
         for task in task_graph.iter_bfs(out_of_sync_tasks):
             # We unfortunately need (?) to re-run in_sync here in case

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -14,12 +14,12 @@ def clean(force=False, pause=0.5):
 
     # print a warning message before removing all tasks. Briefly
     # pause to make sure user sees the message at the top.
-    if not force:
+    if not (force or export):
         print(colors.red(
             "Please confirm that you want to delete the following files."
         ))
         time.sleep(pause)
-        for task in task_graph:
+        for task in task_graph.task_list:
             print(task.creates_message())
         yesno = raw_input(colors.red("Delete aforementioned files? [Y/n] "))
         if yesno == '':

--- a/workflow/exceptions.py
+++ b/workflow/exceptions.py
@@ -1,10 +1,15 @@
-class ConfigurationNotFound(Exception):
+# convenience exception to make it easy to not print traceback when
+# run from the command line
+class CommandLineException(Exception):
+    pass
+
+class ConfigurationNotFound(CommandLineException):
     def __init__(self, config_filename, cwd):
         self.config_filename = config_filename
         self.cwd = cwd
 
     def __str__(self):
-        return "\nNo configuration file called '%s' found in directory\n'%s'"%(
+        return "No configuration file called '%s' found in directory\n'%s'"%(
             self.config_filename, 
             self.cwd,
         )

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -441,7 +441,6 @@ class TaskGraph(object):
             # now add the task dependency
             task.add_task_dependency(dependent_task)
 
-
     def link_dependencies(self):
         """Iterate over all tasks and make connections between tasks based on
         their dependencies.

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -292,14 +292,16 @@ class Task(object):
             msg = color(msg)
         return msg
 
-    def command_message(self, command=None, color=colors.bold_white):
+    def command_message(self, command=None, color=colors.bold_white,
+                        pre="|-> "):
         command = command or self.command
         if isinstance(command, (list, tuple)):
             msg = []
             for subcommand in command:
-                msg.append(self.command_message(command=subcommand, color=color))
+                msg.append(self.command_message(command=subcommand, 
+                                                color=color, pre=pre))
             return '\n'.join(msg)
-        msg = "|-> " + command
+        msg = pre + command
         if color:
             msg = color(msg)
         return msg
@@ -534,7 +536,7 @@ class TaskGraph(object):
         for task_id, duration in self.task_durations.iteritems():
             self.task_durations[task_id] = float(duration)
 
-    def save_state(self, dry_run=False):
+    def save_state(self):
         """Save the states of all elements (files, databases, etc). If the
         state file hasn't been stored yet, it creates a new one.
         """
@@ -556,6 +558,5 @@ class TaskGraph(object):
                     raise ElementNotFound(element)
                 self.after_element_states[element] = state
 
-        if not dry_run:
-            self.write_to_storage(self.after_element_states, self.abs_state_path)
+        self.write_to_storage(self.after_element_states, self.abs_state_path)
         self.write_to_storage(self.task_durations, self.abs_duration_path)

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -215,9 +215,12 @@ class Task(object):
         if pipe.returncode != 0:
             sys.exit(pipe.returncode)
 
+    def clean_command(self):
+        return "rm -rf %s" % self.creates
+
     def clean(self):
         """Remove the specified target"""
-        self.run("rm -rf %s" % self.creates)
+        self.run(self.clean_command())
         print("removed %s" % self.creates_message())
 
     def execute(self, command=None):
@@ -460,13 +463,19 @@ class TaskGraph(object):
         else:
             return "%.2f" % (duration / 60 / 60 / 24) + " d"
 
-    def clean(self):
+    def clean(self, export=False):
         """Run clean on every task and remove the state cache file
         """
         for task in self.task_list:
-            task.clean()
+            if export:
+                print(task.clean_command())
+            else:
+                task.clean()
         if os.path.exists(self.abs_state_path):
-            os.remove(self.abs_state_path)
+            if export:
+                print("rm -f %s" % self.abs_state_path)
+            else:
+                os.remove(self.abs_state_path)
 
     def duration_message(self, tasks=None, color=colors.blue):
         tasks = tasks or self.task_list


### PR DESCRIPTION
Sometimes its just nice to have a shell script. With --force, exports shell script for entire workflow. Otherwise just exports for tasks that are out of sync. Behavior should be very similar to --dry-run in that it doesn't actually run any tasks, just exports the sequence of commands that needs to be run
