### PR TITLE
ability to run subanalysis on specified targets

### DIFF
--- a/bin/workflow
+++ b/bin/workflow
@@ -23,8 +23,9 @@ parser.add_argument(
     'task_ids',
     metavar='task',
     type=str,
+    action='append',
     choices=get_available_tasks(),
-    nargs='*',
+    nargs='?', # '*', this isn't working for some reason
     help='Specify particular tasks to run.',
 )
 
@@ -60,11 +61,18 @@ parser.add_argument(
 
 # parse arguemnts and run it
 args = parser.parse_args()
+
+# cast the task_ids 
+task_ids = args.task_ids
+if None in task_ids:
+    task_ids = None
+
+# execute the command
 try:
     if args.clean:
         clean(force=args.force, export=args.export)
     else:
-        execute(task_ids=args.task_ids, force=args.force, dry_run=args.dry_run,
+        execute(task_ids=task_ids, force=args.force, dry_run=args.dry_run,
                 export=args.export)
 except CommandLineException, e:
     print(e)

--- a/bin/workflow
+++ b/bin/workflow
@@ -9,12 +9,23 @@ import sys
 import os
 import ConfigParser
 
+from workflow.parser import get_available_tasks
 from workflow.commands import execute, clean
 from workflow.exceptions import CommandLineException
 
 # setup the option parser
 parser = argparse.ArgumentParser(
     description=__doc__,
+)
+
+# positional arguments
+parser.add_argument(
+    'tasks',
+    metavar='task',
+    type=str,
+    choices=get_available_tasks(),
+    nargs='*',
+    help='Specify particular tasks to run.',
 )
 
 # can only specify one of --force or --dry-run

--- a/bin/workflow
+++ b/bin/workflow
@@ -18,12 +18,15 @@ parser = argparse.ArgumentParser(
     description=__doc__,
 )
 
-# positional arguments
+# make it possible for users to specify task_ids on the command line. 
+#
+# NOTE: for some reason, nargs='*' is not working when you don't
+# specify any tasks. Not sure if this is a pythong 2.7 problem or
+# what, but nothing seemed to work with this.
 parser.add_argument(
     'task_ids',
     metavar='task',
     type=str,
-    action='append',
     choices=get_available_tasks(),
     nargs='?', # '*', this isn't working for some reason
     help='Specify particular tasks to run.',
@@ -61,18 +64,11 @@ parser.add_argument(
 
 # parse arguemnts and run it
 args = parser.parse_args()
-
-# cast the task_ids 
-task_ids = args.task_ids
-if None in task_ids:
-    task_ids = None
-
-# execute the command
 try:
     if args.clean:
         clean(force=args.force, export=args.export)
     else:
-        execute(task_ids=task_ids, force=args.force, dry_run=args.dry_run,
+        execute(task_ids=args.task_ids, force=args.force, dry_run=args.dry_run,
                 export=args.export)
 except CommandLineException, e:
     print(e)

--- a/bin/workflow
+++ b/bin/workflow
@@ -24,12 +24,12 @@ parser = argparse.ArgumentParser(
 # specify any tasks. Not sure if this is a pythong 2.7 problem or
 # what, but nothing seemed to work with this.
 parser.add_argument(
-    'task_ids',
+    'task_id',
     metavar='task',
     type=str,
     choices=get_available_tasks(),
     nargs='?', # '*', this isn't working for some reason
-    help='Specify particular tasks to run.',
+    help='Specify a particular task to run.',
 )
 
 # can only specify one of --force or --dry-run
@@ -68,7 +68,7 @@ try:
     if args.clean:
         clean(force=args.force, export=args.export)
     else:
-        execute(task_ids=args.task_ids, force=args.force, dry_run=args.dry_run,
+        execute(task_id=args.task_id, force=args.force, dry_run=args.dry_run,
                 export=args.export)
 except CommandLineException, e:
     print(e)

--- a/bin/workflow
+++ b/bin/workflow
@@ -20,7 +20,7 @@ parser = argparse.ArgumentParser(
 
 # positional arguments
 parser.add_argument(
-    'tasks',
+    'task_ids',
     metavar='task',
     type=str,
     choices=get_available_tasks(),
@@ -41,7 +41,7 @@ parser.add_argument(
     '-d', '--dry-run',
     action="store_true",
     help=(
-        "Do not run workflow, just report which tasks woulc be run and how "
+        "Do not run workflow, just report which tasks would be run and how "
         "long it would take."
     ),
 )
@@ -64,7 +64,8 @@ try:
     if args.clean:
         clean(force=args.force, export=args.export)
     else:
-        execute(force=args.force, dry_run=args.dry_run, export=args.export)
+        execute(task_ids=args.task_ids, force=args.force, dry_run=args.dry_run,
+                export=args.export)
 except CommandLineException, e:
     print(e)
     sys.exit(1)

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -33,12 +33,18 @@ def clean(force=False, export=False, pause=0.5):
         print("cd %s" % task_graph.root_directory)
     task_graph.clean(export=export)
 
-def execute(force=False, dry_run=False, export=False):
+def execute(task_ids=None, force=False, dry_run=False, export=False):
     """Execute the task workflow.
     """
 
     # load the task graph
     task_graph = load_task_graph()
+
+    # if any tasks are specified, limit the task graph to only those
+    # tasks that are required to create the specified tasks
+    if task_ids is not None:
+        task_graph = task_graph.subgraph_needed_for(task_ids)
+        print len(task_graph.task_list)
 
     # iterate through every task in the task graph and find the set of
     # tasks that have to be executed. we do this first so we can alert

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -33,7 +33,7 @@ def clean(force=False, export=False, pause=0.5):
         print("cd %s" % task_graph.root_directory)
     task_graph.clean(export=export)
 
-def execute(task_ids=None, force=False, dry_run=False, export=False):
+def execute(task_id=None, force=False, dry_run=False, export=False):
     """Execute the task workflow.
     """
 
@@ -42,8 +42,8 @@ def execute(task_ids=None, force=False, dry_run=False, export=False):
 
     # if any tasks are specified, limit the task graph to only those
     # tasks that are required to create the specified tasks
-    if task_ids is not None:
-        task_graph = task_graph.subgraph_needed_for(task_ids)
+    if task_id is not None:
+        task_graph = task_graph.subgraph_needed_for([task_id])
         print len(task_graph.task_list)
 
     # iterate through every task in the task graph and find the set of

--- a/workflow/parser.py
+++ b/workflow/parser.py
@@ -9,33 +9,33 @@ from . import tasks
 # the command line somehow)
 CONFIG_FILENAME = "workflow.yaml"
 
-def find_config_path(config_filename=CONFIG_FILENAME):
+def find_config_path():
     """Recursively decend into parent directories looking for the 
     """
 
     config_path = ''
     directory = os.getcwd()
     while directory:
-        filename = os.path.join(directory, config_filename)
+        filename = os.path.join(directory, CONFIG_FILENAME)
         if os.path.exists(filename):
             config_path = filename
             break
         directory = os.path.sep.join(directory.split(os.path.sep)[:-1])
     if not config_path:
         raise exceptions.ConfigurationNotFound(
-            config_filename,
+            CONFIG_FILENAME,
             os.getcwd()
         )
     return config_path
 
-def load_task_graph(config_path=None):
+def load_task_graph():
     """Load the task graph from the configuration file located at
     config_path
     """
 
     # look for workflow configuration file if it isn't already
     # specified
-    config_path = config_path or find_config_path()
+    config_path = find_config_path()
 
     # load the data
     with open(config_path) as stream:
@@ -52,3 +52,11 @@ def load_task_graph(config_path=None):
     task_graph.load_state()
 
     return task_graph
+
+def get_available_tasks():
+    """Return the available set of tasks that are specified in the
+    configuration file. These are returned in the order they are
+    specified in the configuration files.
+    """
+    task_graph = load_task_graph()
+    return [task.id for task in task_graph.task_list]


### PR DESCRIPTION
Only run these tasks (and any out-of-date dependencies)

``` bash
workflow data/result.png data/download.tgz
```

Should also be able to remove specific `creates` targets with `--clean`

``` bash
workflow --clean data/result.png data/download.tgz
```
