### PR TITLE
global variables in workflow.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ git clone https://github.com/YOUR-USERNAME/data-workflow.git
 
 ```bash
 mkvirtualenv data-workflow
-pip install -r REQUIREMENTS
+pip install -r REQUIREMENTS -r examples/REQUIREMENTS
 ```
 
 3. Adjust `PYTHONPATH`, `PATH`, and python environment so you can use

--- a/examples/REQUIREMENTS
+++ b/examples/REQUIREMENTS
@@ -1,0 +1,1 @@
+matplotlib

--- a/examples/REQUIREMENTS
+++ b/examples/REQUIREMENTS
@@ -1,2 +1,3 @@
 numpy>=1.4
 matplotlib
+textblob

--- a/examples/REQUIREMENTS
+++ b/examples/REQUIREMENTS
@@ -1,1 +1,2 @@
+numpy>=1.4
 matplotlib

--- a/examples/branching/src/autocorrelation.py
+++ b/examples/branching/src/autocorrelation.py
@@ -1,0 +1,18 @@
+"""Plot the autocorrelation of the specified column
+"""
+
+import sys
+import csv
+
+import matplotlib.pyplot as plot
+
+col = int(sys.argv[2])
+
+data = []
+with open(sys.argv[1], 'r') as stream:
+    reader = csv.reader(stream, delimiter='\t')
+    for row in reader:
+        data.append(float(row[col]))
+
+scatter = plot.acorr(data, linewidth=3, normed=True)
+plot.savefig(sys.argv[3])

--- a/examples/branching/src/autocorrelation.py
+++ b/examples/branching/src/autocorrelation.py
@@ -6,13 +6,12 @@ import csv
 
 import matplotlib.pyplot as plot
 
+import loaders
+
+tsv_filename = sys.argv[1]
 col = int(sys.argv[2])
 
-data = []
-with open(sys.argv[1], 'r') as stream:
-    reader = csv.reader(stream, delimiter='\t')
-    for row in reader:
-        data.append(float(row[col]))
+data = loaders.data_from_tsv(tsv_filename, [col])[0]
 
 scatter = plot.acorr(data, linewidth=3, normed=True)
 plot.savefig(sys.argv[3])

--- a/examples/branching/src/loaders.py
+++ b/examples/branching/src/loaders.py
@@ -1,0 +1,26 @@
+"""module of general purpose utilities for reading in the data from disk
+"""
+import csv
+
+def _init_data(cols):
+    return [[] for col in cols]    
+
+def data_from_tsv(tsv_filename, cols=None):
+    """Load data from tab separated values file located in columns
+    specified in cols
+    """
+
+    if cols is not None:
+        data = _init_data(cols)
+
+    with open(tsv_filename, 'r') as stream:
+        reader = csv.reader(stream, delimiter='\t')
+        for row in reader:
+
+            if cols is None:
+                cols = range(len(row))
+                data = _init_data(cols)
+
+            for i, col in enumerate(cols):
+                data[i].append(float(row[col]))
+    return data

--- a/examples/branching/src/pdf.py
+++ b/examples/branching/src/pdf.py
@@ -1,0 +1,18 @@
+"""Visualize the distribution of values
+"""
+
+import sys
+import csv
+
+import matplotlib.pyplot as plot
+
+col = int(sys.argv[2])
+
+data = []
+with open(sys.argv[1], 'r') as stream:
+    reader = csv.reader(stream, delimiter='\t')
+    for row in reader:
+        data.append(float(row[col]))
+
+scatter = plot.hist(data, 30, normed=1, facecolor='g', alpha=0.6)
+plot.savefig(sys.argv[3])

--- a/examples/branching/src/pdf.py
+++ b/examples/branching/src/pdf.py
@@ -6,13 +6,12 @@ import csv
 
 import matplotlib.pyplot as plot
 
+import loaders
+
+tsv_filename = sys.argv[1]
 col = int(sys.argv[2])
 
-data = []
-with open(sys.argv[1], 'r') as stream:
-    reader = csv.reader(stream, delimiter='\t')
-    for row in reader:
-        data.append(float(row[col]))
+data = loaders.data_from_tsv(tsv_filename, [col])[0]
 
 scatter = plot.hist(data, 30, normed=1, facecolor='g', alpha=0.6)
 plot.savefig(sys.argv[3])

--- a/examples/branching/src/run_simulation.py
+++ b/examples/branching/src/run_simulation.py
@@ -1,0 +1,14 @@
+"""Run a dummy simulation that outputs tab-separated values
+"""
+
+import random
+import csv
+import sys
+
+writer = csv.writer(sys.stdout, delimiter='\t')
+for i in range(10000):
+    writer.writerow([
+        random.random(),
+        random.expovariate(2.0),
+        random.normalvariate(10, 15),
+    ])

--- a/examples/branching/src/scatterplot.py
+++ b/examples/branching/src/scatterplot.py
@@ -6,12 +6,11 @@ import csv
 
 import matplotlib.pyplot as plot
 
-x, y = [], []
-with open(sys.argv[1], 'r') as stream:
-    reader = csv.reader(stream, delimiter='\t')
-    for row in reader:
-        x.append(float(row[0]))
-        y.append(float(row[1]))
+import loaders
+
+tsv_filename = sys.argv[1]
+
+x, y = loaders.data_from_tsv(tsv_filename)
 
 scatter = plot.scatter(x, y)
 plot.setp(scatter, color='r', linewidth=0.0, alpha=0.05)

--- a/examples/branching/src/scatterplot.py
+++ b/examples/branching/src/scatterplot.py
@@ -1,0 +1,18 @@
+"""Visualize the scatter plot of x, y
+"""
+
+import sys
+import csv
+
+import matplotlib.pyplot as plot
+
+x, y = [], []
+with open(sys.argv[1], 'r') as stream:
+    reader = csv.reader(stream, delimiter='\t')
+    for row in reader:
+        x.append(float(row[0]))
+        y.append(float(row[1]))
+
+scatter = plot.scatter(x, y)
+plot.setp(scatter, color='r', linewidth=0.0, alpha=0.05)
+plot.savefig(sys.argv[2])

--- a/examples/branching/workflow.yaml
+++ b/examples/branching/workflow.yaml
@@ -39,8 +39,8 @@ command: python {{depends|join(' ')}} 1 {{creates}}
 # create a figure for the autocorrelation between consecutive x,y
 # pairs
 ---
-creates: data/x_y_autocorrelation.png
+creates: data/x_autocorrelation.png
 depends: 
   - src/autocorrelation.py
   - data/x_y.dat
-command: python {{depends|join(' ')}} > {{creates}}
+command: python {{depends|join(' ')}} 0 {{creates}}

--- a/examples/branching/workflow.yaml
+++ b/examples/branching/workflow.yaml
@@ -18,7 +18,7 @@ creates: data/x_y_correlation.png
 depends: 
   - src/scatterplot.py
   - data/x_y.dat
-command: python {{depends|join(' ')}} > {{creates}}
+command: python {{depends|join(' ')}} {{creates}}
 
 # create a figure to display the distribution of x
 ---

--- a/examples/branching/workflow.yaml
+++ b/examples/branching/workflow.yaml
@@ -26,7 +26,7 @@ creates: data/x_pdf.png
 depends: 
   - src/pdf.py
   - data/x_y.dat
-command: python {{depends|join(' ')}} > {{creates}}
+command: python {{depends|join(' ')}} 0 {{creates}}
 
 # create a figure to display the distribution of y
 ---
@@ -34,7 +34,7 @@ creates: data/y_pdf.png
 depends: 
   - src/pdf.py
   - data/x_y.dat
-command: python {{depends|join(' ')}} > {{creates}}
+command: python {{depends|join(' ')}} 1 {{creates}}
 
 # create a figure for the autocorrelation between consecutive x,y
 # pairs

--- a/examples/branching/workflow.yaml
+++ b/examples/branching/workflow.yaml
@@ -13,6 +13,7 @@ depends: data/results.tsv
 command: cut -f1,2 {{depends}} > {{creates}}
 
 # create a figure for the correlation between x and y
+# QUESTION: SHOULD THIS DEPEND ON src/loaders.py?
 ---
 creates: data/x_y_correlation.png
 depends: 
@@ -21,6 +22,7 @@ depends:
 command: python {{depends|join(' ')}} {{creates}}
 
 # create a figure to display the distribution of x
+# QUESTION: SHOULD THIS DEPEND ON src/loaders.py?
 ---
 creates: data/x_pdf.png
 depends: 
@@ -29,6 +31,7 @@ depends:
 command: python {{depends|join(' ')}} 0 {{creates}}
 
 # create a figure to display the distribution of y
+# QUESTION: SHOULD THIS DEPEND ON src/loaders.py?
 ---
 creates: data/y_pdf.png
 depends: 
@@ -38,6 +41,7 @@ command: python {{depends|join(' ')}} 1 {{creates}}
 
 # create a figure for the autocorrelation between consecutive x,y
 # pairs
+# QUESTION: SHOULD THIS DEPEND ON src/loaders.py?
 ---
 creates: data/x_autocorrelation.png
 depends: 

--- a/examples/branching/workflow.yaml
+++ b/examples/branching/workflow.yaml
@@ -1,50 +1,62 @@
-# run a simulation
+# this is an example of how to use global variables throughout the
+# workflow.yaml to make it easy to switch between columns of
+# analysis. 
 ---
-creates: data/results.tsv
-depends: src/run_simulation.py
-command: 
-  - mkdir -p $(dirname {{creates}})
-  - python {{depends}} > {{creates}}
+# Global variables that can be used across several different
+# tasks. See how these are used below
+x_col: 0
+y_col: 1
 
-# process the results
----
-creates: data/x_y.dat
-depends: data/results.tsv
-command: cut -f1,2 {{depends}} > {{creates}}
+# this evokes global variable mode
+tasks: 
 
-# create a figure for the correlation between x and y
-# QUESTION: SHOULD THIS DEPEND ON src/loaders.py?
----
-creates: data/x_y_correlation.png
-depends: 
-  - src/scatterplot.py
-  - data/x_y.dat
-command: python {{depends|join(' ')}} {{creates}}
-
-# create a figure to display the distribution of x
-# QUESTION: SHOULD THIS DEPEND ON src/loaders.py?
----
-creates: data/x_pdf.png
-depends: 
-  - src/pdf.py
-  - data/x_y.dat
-command: python {{depends|join(' ')}} 0 {{creates}}
-
-# create a figure to display the distribution of y
-# QUESTION: SHOULD THIS DEPEND ON src/loaders.py?
----
-creates: data/y_pdf.png
-depends: 
-  - src/pdf.py
-  - data/x_y.dat
-command: python {{depends|join(' ')}} 1 {{creates}}
-
-# create a figure for the autocorrelation between consecutive x,y
-# pairs
-# QUESTION: SHOULD THIS DEPEND ON src/loaders.py?
----
-creates: data/x_autocorrelation.png
-depends: 
-  - src/autocorrelation.py
-  - data/x_y.dat
-command: python {{depends|join(' ')}} 0 {{creates}}
+  # run a simulation
+  - 
+    creates: data/results.tsv
+    depends: src/run_simulation.py
+    command: 
+      - mkdir -p $(dirname {{creates}})
+      - python {{depends}} > {{creates}}
+  
+  # process the results
+  -
+    creates: data/x_y.dat
+    depends: data/results.tsv
+    command: cut -f{{x_col+1}},{{y_col+1}} {{depends}} > {{creates}}
+  
+  # create a figure for the correlation between x and y
+  # QUESTION: SHOULD THIS DEPEND ON src/loaders.py?
+  -
+    creates: data/x_y_correlation.png
+    depends: 
+      - src/scatterplot.py
+      - data/x_y.dat
+    command: python {{depends|join(' ')}} {{creates}}
+  
+  # create a figure to display the distribution of x
+  # QUESTION: SHOULD THIS DEPEND ON src/loaders.py?
+  -
+    creates: data/x_pdf.png
+    depends: 
+      - src/pdf.py
+      - data/x_y.dat
+    command: python {{depends|join(' ')}} {{x_col}} {{creates}}
+  
+  # create a figure to display the distribution of y
+  # QUESTION: SHOULD THIS DEPEND ON src/loaders.py?
+  -
+    creates: data/y_pdf.png
+    depends: 
+      - src/pdf.py
+      - data/x_y.dat
+    command: python {{depends|join(' ')}} {{y_col}} {{creates}}
+  
+  # create a figure for the autocorrelation between consecutive x,y
+  # pairs
+  # QUESTION: SHOULD THIS DEPEND ON src/loaders.py?
+  -
+    creates: data/x_autocorrelation.png
+    depends: 
+      - src/autocorrelation.py
+      - data/x_y.dat
+    command: python {{depends|join(' ')}} {{x_col}} {{creates}}

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -81,7 +81,7 @@ def execute(task_id=None, force=False, dry_run=False, export=False):
     # if no tasks were executed, then alert the user that nothing
     # needed to be run
     else:
-        print("No tasks were run in the workflow defined in '%s'" % (
+        print("No tasks are out of sync in the workflow defined in '%s'" % (
             os.path.relpath(task_graph.config_path, os.getcwd())
         ))
         


### PR DESCRIPTION
ran across a situation in one of the examples when it would have been convenient to have some global variables available in the `command` jinja templates. Perhaps we could accept two types of YAML formats, one that just lists tasks, and another that is an object with key:values that are global variables to use throughout the workflow, but with a special key called `tasks` (or something) that would be the list of tasks. Something like this:

``` yaml

---
x_col: 1
y_col: 2
tasks:
  # process the results
  -
  creates: data/x_y.dat
  depends: data/results.tsv
  command: cut -f{{x_col}},{{y_col}} {{depends}} > {{creates}}

  # create a figure for the correlation between x and y
  -
  creates: data/x_y_correlation.png
  depends: 
    - src/scatterplot.py
    - data/x_y.dat
  command: python {{depends|join(' ')}} {{creates}}

  # create a figure to display the distribution of x
  -
  creates: data/x_pdf.png
  depends: 
    - src/pdf.py
    - data/x_y.dat
  command: python {{depends|join(' ')}} {{x_col}} {{creates}}

  # create a figure to display the distribution of y
  -
  creates: data/y_pdf.png
  depends: 
    - src/pdf.py
    - data/x_y.dat
  command: python {{depends|join(' ')}} {{y_col}} {{creates}}
```
