### PR TITLE
implement --backup / --restore

### DIFF
--- a/bin/workflow
+++ b/bin/workflow
@@ -11,7 +11,7 @@ import ConfigParser
 
 from workflow.parser import get_available_tasks
 from workflow.commands import execute, clean, archive
-from workflow.exceptions import CommandLineException
+from workflow.exceptions import CommandLineException, ConfigurationNotFound
 
 # setup the option parser
 parser = argparse.ArgumentParser(
@@ -23,11 +23,15 @@ parser = argparse.ArgumentParser(
 # NOTE: for some reason, nargs='*' is not working when you don't
 # specify any tasks. Not sure if this is a pythong 2.7 problem or
 # what, but nothing seemed to work with this.
+try:
+    available_tasks = get_available_tasks()
+except ConfigurationNotFound:
+    available_tasks = []
 parser.add_argument(
     'task_id',
     metavar='task',
     type=str,
-    choices=get_available_tasks(),
+    choices=available_tasks,
     nargs='?', # '*', this isn't working for some reason
     help='Specify a particular task to run.',
 )

--- a/bin/workflow
+++ b/bin/workflow
@@ -10,7 +10,7 @@ import os
 import ConfigParser
 
 from workflow.parser import get_available_tasks
-from workflow.commands import execute, clean
+from workflow.commands import execute, clean, archive
 from workflow.exceptions import CommandLineException
 
 # setup the option parser
@@ -62,11 +62,28 @@ parser.add_argument(
     help="Confirm before removing all `creates` targets defined in workflow.",
 )
 
+# Here are a few handy commands for backing up a workflow and
+# restoring it. This will hopefully make debugging a lot easier! Can
+# only specify one of these options
+group = parser.add_mutually_exclusive_group()
+group.add_argument(
+    '--backup',
+    action="store_true",
+    help="Backup the current state of the workflow."
+)
+group.add_argument(
+    '--restore',
+    action="store_true",
+    help="Restore the state of the workflow."
+)
+
 # parse arguemnts and run it
 args = parser.parse_args()
 try:
     if args.clean:
         clean(force=args.force, export=args.export)
+    elif args.backup or args.restore:
+        archive(backup=args.backup, restore=args.restore)
     else:
         execute(task_id=args.task_id, force=args.force, dry_run=args.dry_run,
                 export=args.export)

--- a/bin/workflow
+++ b/bin/workflow
@@ -8,8 +8,9 @@ import argparse
 import sys
 import os
 import ConfigParser
+import types
 
-from workflow.parser import get_available_tasks
+from workflow.parser import get_available_tasks, get_available_archives
 from workflow.commands import execute, clean, archive
 from workflow.exceptions import CommandLineException, ConfigurationNotFound
 
@@ -69,6 +70,10 @@ parser.add_argument(
 # Here are a few handy commands for backing up a workflow and
 # restoring it. This will hopefully make debugging a lot easier! Can
 # only specify one of these options
+try:
+    available_archives = get_available_archives()
+except ConfigurationNotFound:
+    available_archives = []
 group = parser.add_mutually_exclusive_group()
 group.add_argument(
     '--backup',
@@ -77,7 +82,9 @@ group.add_argument(
 )
 group.add_argument(
     '--restore',
-    action="store_true",
+    choices=available_archives,
+    default=False,
+    nargs='?',
     help="Restore the state of the workflow."
 )
 
@@ -86,7 +93,9 @@ args = parser.parse_args()
 try:
     if args.clean:
         clean(force=args.force, export=args.export)
-    elif args.backup or args.restore:
+    elif args.backup or isinstance(args.restore, (str, types.NoneType)):
+        if args.restore is None:
+            args.restore = available_archives[-1]
         archive(backup=args.backup, restore=args.restore)
     else:
         execute(task_id=args.task_id, force=args.force, dry_run=args.dry_run,

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -89,3 +89,10 @@ def execute(task_id=None, force=False, dry_run=False, export=False):
     # out of sync
     if not (dry_run or export):
         task_graph.save_state()
+
+def archive(backup=False, restore=False):
+    """Interact with archives of the workflow, by either backing it up or
+    restoring it from a previous backup.
+    """
+    pass
+

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -95,9 +95,6 @@ def archive(backup=False, restore=False):
     restoring it from a previous backup.
     """
     
-    # TODO: how should this behave if a task is specified on the
-    # command line? 
-
     # load in the task_graph
     task_graph = load_task_graph()
 
@@ -109,4 +106,4 @@ def archive(backup=False, restore=False):
     # ask the user to confirm which archive to restore before doing
     # anything.
     if restore:
-        task_graph.restore_archive()
+        task_graph.restore_archive(restore)

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -94,5 +94,19 @@ def archive(backup=False, restore=False):
     """Interact with archives of the workflow, by either backing it up or
     restoring it from a previous backup.
     """
-    pass
+    
+    # TODO: how should this behave if a task is specified on the
+    # command line? 
 
+    # load in the task_graph
+    task_graph = load_task_graph()
+
+    # create an ensemble of filenames that need to be archived
+    if backup:
+        task_graph.write_archive()
+
+    # find an archive to restore and restore it. This should probably
+    # ask the user to confirm which archive to restore before doing
+    # anything.
+    if restore:
+        task_graph.restore_archive()

--- a/workflow/parser.py
+++ b/workflow/parser.py
@@ -64,3 +64,10 @@ def get_available_tasks():
     """
     task_graph = load_task_graph()
     return [task.id for task in task_graph.task_list]
+
+def get_available_archives():
+    """Return the list of available archives that are stored in
+    .workflow/archives
+    """
+    task_graph = load_task_graph()
+    return task_graph.get_available_archives()

--- a/workflow/parser.py
+++ b/workflow/parser.py
@@ -1,3 +1,7 @@
+"""This set of modules is intended to parse and process the
+CONFIG_FILENAME, workflow.yaml
+"""
+
 import os
 
 import yaml

--- a/workflow/shell.py
+++ b/workflow/shell.py
@@ -1,0 +1,15 @@
+"""Module for executing commands on the command line
+"""
+import subprocess
+import sys
+
+def run(directory, command):
+    """Run the specified shell command using Fabric-like behavior"""
+    wrapped_command = "cd %s && %s" % (directory, command)
+    pipe = subprocess.Popen(
+        wrapped_command, shell=True, 
+        stdout=sys.stdout, stderr=sys.stderr
+    )
+    pipe.communicate()
+    if pipe.returncode != 0:
+        sys.exit(pipe.returncode)

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -615,8 +615,9 @@ class TaskGraph(object):
         
         # for now, create archives based on the date. 
         # 
-        # TODO: it would probably be better to specify by hg/git hash
-        # id but this will do for now
+        # TODO: would it be better to specify by hg/git hash id? Doing
+        # dates for now to make it easy to identify a good default
+        # archive to restore in self.restore_archive (the last one)
         now = datetime.datetime.now()
         if not os.path.exists(self.abs_archive_dir):
             os.makedirs(self.abs_archive_dir)

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -627,7 +627,11 @@ class TaskGraph(object):
 
         # get the set of all filenames that should be archived based
         # on the current workflow specification
-        all_filenames = set([os.path.basename(self.config_path)])
+        all_filenames = set([
+            os.path.basename(self.config_path),
+            self.state_path,
+            self.duration_path,
+        ])
         for task in self.task_list:
             all_filenames.update(task.get_all_filenames())
 

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -641,20 +641,25 @@ class TaskGraph(object):
         sys.stdout.flush()
         shell.run(self.root_directory, command)
 
-        # TODO: what happens if equivalent archive already exists?
-
-    def restore_archive(self):
-        """Method to restore a previous archived workflow
+    def restore_archive(self, archive):
+        """Method to restore a previous archived workflow specified in
+        `archive`. The archive path should be relative to the root of
+        the project.
         """
-
-        # for now, restore the last archive in our archive directory. 
-        #
-        # TODO: it would probably be better to interact with the user
-        # to determine which archive should be used
-        available_archives = glob.glob(os.path.join(self.abs_archive_dir, '*'))
-        available_archives.sort()
-        archive_name = available_archives[-1]
+        archive_name = os.path.join(self.root_directory, archive)
         command = "tar xjf %s" % archive_name
         print(colors.bold_white(command))
         sys.stdout.flush()
         shell.run(self.root_directory, command)
+
+    def get_available_archives(self):
+        """Method to list all of the available archives"""
+        available_archives = self.get_abs_available_archives()
+        return [os.path.relpath(a, self.root_directory) 
+                for a in available_archives]
+
+    def get_abs_available_archives(self):
+        """Method to list all of the available archives"""
+        available_archives = glob.glob(os.path.join(self.abs_archive_dir, '*'))
+        available_archives.sort()
+        return available_archives

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -1,16 +1,18 @@
 import sys
 import os
-import subprocess
 import time
 import hashlib
 import csv
 import StringIO
 import collections
+import datetime
+import glob
 
 import jinja2
 
 from .exceptions import InvalidTaskDefinition, ElementNotFound, NonUniqueTask
 from . import colors
+from . import shell
 
 class Task(object):
 
@@ -75,6 +77,18 @@ class Task(object):
     def reset_task_dependencies(self):
         self.upstream_tasks.clear()
         self.downstream_tasks.clear()
+
+    def get_all_filenames(self):
+        """Identify the set of all filenames that pertain to this task
+        """
+        # TODO: when we allow for non-filesystem targets, this will
+        # have to change to accomodate
+        all_filenames = [self.creates]
+        if isinstance(self.depends, (list, tuple)):
+            all_filenames.extend(self.depends)
+        elif self.depends is not None:
+            all_filenames.append(self.depends)
+        return all_filenames
 
     def get_stream_state(self, stream, block_size=2**20):
         """Read in a stream in relatively small `block_size`s to make sure we
@@ -210,14 +224,7 @@ class Task(object):
 
     def run(self, command):
         """Run the specified shell command using Fabric-like behavior"""
-        wrapped_command = "cd %s && %s" % (self.root_directory, command)
-        pipe = subprocess.Popen(
-            wrapped_command, shell=True, 
-            stdout=sys.stdout, stderr=sys.stderr
-        )
-        pipe.communicate()
-        if pipe.returncode != 0:
-            sys.exit(pipe.returncode)
+        return shell.run(self.root_directory, command)
 
     def clean_command(self):
         return "rm -rf %s" % self.creates
@@ -325,6 +332,7 @@ class TaskGraph(object):
     # relative location of various storage locations
     state_path = os.path.join(".workflow", "state.csv")
     duration_path = os.path.join(".workflow", "duration.csv")
+    archive_dir = os.path.join(".workflow", "archive")
 
     def __init__(self, config_path):
         self.task_list = []
@@ -542,6 +550,11 @@ class TaskGraph(object):
         """Convenience property for accessing duration storage location"""
         return os.path.join(self.root_directory, self.duration_path)
 
+    @property
+    def abs_archive_dir(self):
+        """Convenience property for accessing the archive location"""
+        return os.path.join(self.root_directory, self.archive_dir)
+
     def read_from_storage(self, dictionary, storage_location):
         if os.path.exists(storage_location):
             with open(storage_location) as stream:
@@ -584,7 +597,7 @@ class TaskGraph(object):
         # TODO: this is a bit of a hack to be able to use Task's
         # get_element_state method. Should probably find a better
         # place to organize this code so we don't have to do that
-        dummy_task = Task(creates="creates", command="command")
+        dummy_task = Task(creates="dummy", command="dummy")
         dummy_task.graph = self
         for element, state in self.after_element_states.iteritems():
             if state is None:
@@ -595,3 +608,49 @@ class TaskGraph(object):
 
         self.write_to_storage(self.after_element_states, self.abs_state_path)
         self.write_to_storage(self.task_durations, self.abs_duration_path)
+
+    def write_archive(self):
+        """Method to backup the current workflow
+        """
+        
+        # for now, create archives based on the date. 
+        # 
+        # TODO: it would probably be better to specify by hg/git hash
+        # id but this will do for now
+        now = datetime.datetime.now()
+        if not os.path.exists(self.abs_archive_dir):
+            os.makedirs(self.abs_archive_dir)
+        archive_name = os.path.join(
+            self.abs_archive_dir,
+            "%s.tar.bz2" % now.strftime("%Y%m%d%H%M%S"),
+        )
+
+        # get the set of all filenames that should be archived based
+        # on the current workflow specification
+        all_filenames = set([os.path.basename(self.config_path)])
+        for task in self.task_list:
+            all_filenames.update(task.get_all_filenames())
+
+        # create the archive
+        command = "tar cjf %s %s" % (archive_name, ' '.join(all_filenames))
+        print(colors.bold_white(command))
+        sys.stdout.flush()
+        shell.run(self.root_directory, command)
+
+        # TODO: what happens if equivalent archive already exists?
+
+    def restore_archive(self):
+        """Method to restore a previous archived workflow
+        """
+
+        # for now, restore the last archive in our archive directory. 
+        #
+        # TODO: it would probably be better to interact with the user
+        # to determine which archive should be used
+        available_archives = glob.glob(os.path.join(self.abs_archive_dir, '*'))
+        available_archives.sort()
+        archive_name = available_archives[-1]
+        command = "tar xjf %s" % archive_name
+        print(colors.bold_white(command))
+        sys.stdout.flush()
+        shell.run(self.root_directory, command)


### PR DESCRIPTION
Sometimes it is really convenient to create an archive of an analysis so you can run an  analysis workflow with the confidence that, no matter what, you have something to fall back on. `workflow --backup` should prepare a bzipped archive in the `.workflow/` directory with a filename like `.workflow/backups/YYYY-MM-DD-HHMMSS.tar.bz2`.

Might also be nice to give the user the ability to `--restore`, or something along those lines, to allow the user to restore the analysis back to the state on such-and-such a date. 

Perhaps this should be tied to a repository hash id for `git`/`hg` to make it easier to restore an analysis to a particular state during the development pipeline?
