### PR TITLE
enable tab completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,13 @@ into conflicts.
 workflow --export          # prints out sequence of shell commands
 ```
 
+**autocomplete.** Autocompletion of available options with workflow is
+enabled by @kislyuk's amazing
+[autocomplete](https://github.com/kislyuk/argcomplete) package. Follow
+instructions to
+[enable global autocomplete](https://github.com/kislyuk/argcomplete#activating-global-completion)
+and you should be all set.
+
 **more info.** For more details about these and other options, see
   `workflow --help`.
 

--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -1,2 +1,3 @@
 PyYAML
 Jinja2
+argcomplete

--- a/bin/workflow
+++ b/bin/workflow
@@ -10,6 +10,8 @@ import os
 import ConfigParser
 import types
 
+import argcomplete
+
 from workflow.parser import get_available_tasks, get_available_archives
 from workflow.commands import execute, clean, archive
 from workflow.exceptions import CommandLineException, ConfigurationNotFound
@@ -88,7 +90,8 @@ group.add_argument(
     help="Restore the state of the workflow."
 )
 
-# parse arguemnts and run it
+# use argcomplete to autocomplete options, the parse arguments and run
+argcomplete.autocomplete(parser)
 args = parser.parse_args()
 try:
     if args.clean:


### PR DESCRIPTION
When you're cranking, its annoying to have to type relatively long `creates` or `alias` names. It would be really nice if you could just tab complete on `creates` targets so that something like this would happen

``` bash
[terminal]$ workflow da[TAB]
[terminal]$ workflow data/[TAB]
reuters21578.tar.gz
reuters21578
corpus.csv
standardized_corpus.csv
tfidf.csv
```

I haven't dont any research into how feasible this is, but it seems like argparse is considerably more awesome and could conceivably make this relatively easy.

https://github.com/kislyuk/argcomplete
