### PR TITLE
make it possible to run a group of tasks really easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ tools, but rather to be the glue that sticks them together.
    `command` key that defines the command that are required to create
    the resource defined in `creates`. You can optionally define a
    `depends` key that lists resources, either filenames on disk or
-   other task `creates` targets, to quickly set up dependency chains.
+   other task `creates` targets, to quickly set up dependency
+   chains. You can optionally omit the `command` key to create
+   pseudotasks that are collections of other tasks for quickly running
+   a subcomponent of the analysis.
 
 3. *Execute your workflow.* From the same directory as the
    `workflow.yaml` file (or any child directory), run `workflow` and
@@ -127,6 +130,18 @@ the `depends` key, multiple steps can be defined in a
 command:
   - mkdir -p $(dirname {{creates}})
   - python {{depends}} > {{creates}}
+```
+
+If the `command` key is omitted, this task is treated like a
+pseudotask to make it easy to group together a collection of other
+tasks like this:
+
+```yaml
+creates: figures         # name of pseudotask
+depends:
+  - path/to/figure/a.png # refers to another task in workflow.yaml
+  - path/to/figure/b.png # refers to another task in workflow.yaml
+  - path/to/figure/c.png # refers to another task in workflow.yaml
 ```
 
 **templating variables.** Importantly, the `command` is rendered as a

--- a/examples/model-correlations/workflow.yaml
+++ b/examples/model-correlations/workflow.yaml
@@ -61,7 +61,9 @@ tasks:
       - data/x_y.dat
     command: python {{depends|join(' ')}} {{x_col}} {{creates}}
 
-  # this is a pseudotarget that is a convenient alias for several subcommands
+  # this is an example of a pseudotask that is a convenient alias for
+  # several subcommands. pseudotasks are tasks that have no `command`
+  # associated with them.
   -
     creates: figures
     depends:

--- a/examples/model-correlations/workflow.yaml
+++ b/examples/model-correlations/workflow.yaml
@@ -60,3 +60,12 @@ tasks:
       - src/autocorrelation.py
       - data/x_y.dat
     command: python {{depends|join(' ')}} {{x_col}} {{creates}}
+
+  # this is a pseudotarget that is a convenient alias for several subcommands
+  -
+    creates: figures
+    depends:
+      - data/x_pdf.png
+      - data/y_pdf.png
+      - data/x_autocorrelation.png
+      - data/x_y_correlation.png

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -48,9 +48,12 @@ def execute(task_id=None, force=False, dry_run=False, export=False):
 
     # iterate through every task in the task graph and find the set of
     # tasks that have to be executed. we do this first so we can alert
-    # the user as to how long this workflow will take
+    # the user as to how long this workflow will take. use breadth
+    # first search on entire task graph to make sure the
+    # out_of_sync_tasks are created in the appropriate order for
+    # subsequent steps.
     out_of_sync_tasks = []
-    for task in task_graph.task_list:
+    for task in task_graph.iter_bfs():
 
         # regardless of whether we force the execution of the command,
         # run the in_sync method, which calculates the state of the

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -20,7 +20,8 @@ def clean(force=False, export=False, pause=0.5):
         ))
         time.sleep(pause)
         for task in task_graph.task_list:
-            print(task.creates_message())
+            if not task.is_pseudotask():
+                print(task.creates_message())
         yesno = raw_input(colors.red("Delete aforementioned files? [Y/n] "))
         if yesno == '':
             yesno = 'y'

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -44,7 +44,6 @@ def execute(task_id=None, force=False, dry_run=False, export=False):
     # tasks that are required to create the specified tasks
     if task_id is not None:
         task_graph = task_graph.subgraph_needed_for([task_id])
-        print len(task_graph.task_list)
 
     # iterate through every task in the task graph and find the set of
     # tasks that have to be executed. we do this first so we can alert
@@ -55,7 +54,7 @@ def execute(task_id=None, force=False, dry_run=False, export=False):
         # regardless of whether we force the execution of the command,
         # run the in_sync method, which calculates the state of the
         # task and all `creates` / `depends` elements
-        if not task.in_sync() or force:
+        if (not task.in_sync() or force) and not task.is_pseudotask():
             out_of_sync_tasks.append(task)
 
     # report the minimum amount of time this will take to execute and

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -69,7 +69,7 @@ def execute(task_id=None, force=False, dry_run=False, export=False):
             # things change during the course of a run. This is not
             # ideal but makes it possible to estimate the duration of
             # a workflow run, which is pretty valuable
-            if not task.in_sync() or force:
+            if (not task.in_sync() or force) and not task.is_pseudotask():
                 if not (dry_run or export):
                     task.execute()
                 elif dry_run:

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -469,11 +469,12 @@ class TaskGraph(object):
             min_duration += self.task_durations.get(task.id, 0.0)
         max_duration, n_unknown, n_tasks = 0.0, 0, 0
         for task in self.iter_bfs(tasks):
-            n_tasks += 1
-            try:
-                max_duration += self.task_durations[task.id]
-            except KeyError:
-                n_unknown += 1
+            if not task.is_pseudotask():
+                n_tasks += 1
+                try:
+                    max_duration += self.task_durations[task.id]
+                except KeyError:
+                    n_unknown += 1
         msg = ''
         if n_unknown>0:
             msg += "%d new tasks with unknown durations.\n" % (

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -283,6 +283,7 @@ class TaskGraph(object):
             for task in updownset.difference(done):
                 if task not in horizon_set:
                     horizon.append(task)
+                    horizon_set.add(task)
         return task_order
 
     def iter_bfs(self, tasks=None):

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -144,8 +144,9 @@ class Task(resources.base.BaseResource):
 
     def clean(self):
         """Remove the specified target"""
-        self.run(self.clean_command())
-        print("removed %s" % self.creates_message())
+        if not self.is_pseudotask():
+            self.run(self.clean_command())
+            print("removed %s" % self.creates_message())
 
     def execute(self, command=None):
         """Run the specified task from the root of the workflow"""

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -547,9 +547,12 @@ class TaskGraph(object):
         state file hasn't been stored yet, it creates a new one.
         """
 
-        # store all of the resource states in a dictionary to save it
-        # to csv
+        # read all of the old storage states first, then over write
+        # the old states with the current states before writing to a
+        # CSV. this is important for situations where a subgraph is
+        # selected to run
         after_resource_states = {}
+        self.read_from_storage(after_resource_states, self.abs_state_path)
         for name, resource in self.resource_dict.iteritems():
             after_resource_states[name] = resource.current_state
 

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -91,6 +91,8 @@ class Task(resources.base.BaseResource):
         #
         # XXXX TODO: use the resources to get at this...
         all_filenames = [self.creates]
+        if self.is_pseudotask():
+            all_filenames = []
         if isinstance(self.depends, (list, tuple)):
             all_filenames.extend(self.depends)
         elif self.depends is not None:


### PR DESCRIPTION
@laurieskelly suggested being able to use pseudotargets to run groups of tasks, kinda like tags

``` yaml

---
# normalize and stem

---
creates: data/standardized_corpus.csv
depends:
  - src/normalize_and_stem.py
  - data/corpus.csv
command: python {{depends|join(' ')}} > {{creates}}

# tfidf

---
creates: data/tfidf.dat
depends:
  - src/calculate_tfidf.py
  - data/standardized_corpus.csv
command: python {{depends|join(' ')}} > {{creates}}

---
creates: something_awesome
depends:
  - data/standardized_corpus.csv
  - data/tfidf.dat
command: echo 'hi'
```

then you could just run `workflow something_awesome` to run all of the associated tasks
