### PR TITLE
behavior of `workflow --clean data/corpus.csv`?

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,9 @@ want to be confident a workflow properly runs from start to finish
 before inviting collaborators. Whatever the case, the `--clean` option
 can be useful for removing all `creates` targets that are defined in
 `workflow.yaml` and the `--force` option can be useful for just
-rerunning all steps, regardless of whether they are out of date.
+rerunning all steps, regardless of whether they are out of date. If
+you just want to remove a particular target, you can use `--clean
+task_id` to only remove that `creates` target.
 
 ```bash
 workflow --clean            # asks user if they want to remove `creates` results

--- a/bin/workflow
+++ b/bin/workflow
@@ -95,7 +95,7 @@ argcomplete.autocomplete(parser)
 args = parser.parse_args()
 try:
     if args.clean:
-        clean(force=args.force, export=args.export)
+        clean(task_id=args.task_id, force=args.force, export=args.export)
     elif args.backup or isinstance(args.restore, (str, types.NoneType)):
         if args.restore is None:
             args.restore = available_archives[-1]

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -5,12 +5,19 @@ from distutils.util import strtobool
 from .parser import load_task_graph
 from . import colors
 
-def clean(force=False, export=False, pause=0.5):
-    """Remove all `creates` targets defined in workflow
+def clean(task_id=None, force=False, export=False, pause=0.5):
+    """Remove all `creates` targets defined in workflow. If a task_id is
+    specified, only remove that target.
     """
 
     # load the task graph
     task_graph = load_task_graph()
+
+    # if a task_id is specified, only remove this particular
+    # task. otherwise, remove everything.
+    task_list = task_graph.task_list
+    if task_id is not None:
+        task_list = [task_graph.task_dict[task_id]]
 
     # print a warning message before removing all tasks. Briefly
     # pause to make sure user sees the message at the top.
@@ -19,7 +26,7 @@ def clean(force=False, export=False, pause=0.5):
             "Please confirm that you want to delete the following files."
         ))
         time.sleep(pause)
-        for task in task_graph.task_list:
+        for task in task_list:
             if not task.is_pseudotask():
                 print(task.creates_message())
         yesno = raw_input(colors.red("Delete aforementioned files? [Y/n] "))
@@ -32,7 +39,7 @@ def clean(force=False, export=False, pause=0.5):
     # `creates` targets
     if export:
         print("cd %s" % task_graph.root_directory)
-    task_graph.clean(export=export)
+    task_graph.clean(export=export, task_list=task_list)
 
 def execute(task_id=None, force=False, dry_run=False, export=False):
     """Execute the task workflow.

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -451,15 +451,16 @@ class TaskGraph(object):
         else:
             return "%.2f" % (duration / 60 / 60 / 24) + " d"
 
-    def clean(self, export=False):
+    def clean(self, export=False, task_list=None):
         """Run clean on every task and remove the state cache file
         """
-        for task in self.task_list:
+        task_list = task_list or self.task_list
+        for task in task_list:
             if export:
                 print(task.clean_command())
             else:
                 task.clean()
-        if os.path.exists(self.abs_state_path):
+        if os.path.exists(self.abs_state_path) and task_list == self.task_list:
             if export:
                 print("rm -f %s" % self.abs_state_path)
             else:


### PR DESCRIPTION
The big thing we need to decide here is how this should behave? Should it _only_ remove `data/corpus.csv` or should it remove `data/corpus.csv` and all its dependencies? 

To me, it seems more natural to only remove `data/corpus.csv` but perhaps others have a different intuitive sense of what it should do. I guess it depends on how this is used in practice so I'll wait for feedback before making any decisions on this...
