### PR TITLE
behavior on keyboard interrupt

### DIFF
--- a/examples/reuters-tfidf/src/parse.py
+++ b/examples/reuters-tfidf/src/parse.py
@@ -46,4 +46,3 @@ for filename in glob.glob(os.path.join(sys.argv[1], "*.sgm")):
         parser.feed(stream.read())
         sys.stdout.flush()
     print >> sys.stderr, 'done!'
-

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -5,6 +5,7 @@ import sys
 
 from .parser import load_task_graph
 from . import colors
+from . import exceptions
 
 def clean(force=False, export=False, pause=0.5):
     """Remove all `creates` targets defined in workflow
@@ -78,7 +79,7 @@ def execute(task_id=None, force=False, dry_run=False, export=False):
                 if not (dry_run or export):
                     try:
                         task.execute()
-                    except KeyboardInterrupt:
+                    except (KeyboardInterrupt, exceptions.ShellError), e:
                         # on keyboard interrupt, make sure all
                         # previously run tasks have their state
                         # properly stored. we do this by delete files
@@ -86,7 +87,7 @@ def execute(task_id=None, force=False, dry_run=False, export=False):
                         # and then saving the state before exiting
                         task.clean()
                         task_graph.save_state()
-                        sys.exit(1)
+                        sys.exit(getattr(e, 'exit_code', 1))
                 elif dry_run:
                     print(task)
                 elif export:

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -80,13 +80,17 @@ def execute(task_id=None, force=False, dry_run=False, export=False):
                     try:
                         task.execute()
                     except (KeyboardInterrupt, exceptions.ShellError), e:
-                        # on keyboard interrupt, make sure all
-                        # previously run tasks have their state
-                        # properly stored. we do this by delete files
-                        # that were in the process of being created
-                        # and then saving the state before exiting
-                        task.clean()
-                        task_graph.save_state()
+                        # on keyboard interrupt or error on executing
+                        # a specific step, make sure all previously
+                        # run tasks have their state properly stored
+                        # and make sure re-running the workflow will
+                        # rerun the task that was underway. we do this
+                        # by saving the state of everything but
+                        # overridding the state of the creates
+                        # resource for this task before exiting
+                        task_graph.save_state(
+                            override_resource_states={task.name:''},
+                        )
                         sys.exit(getattr(e, 'exit_code', 1))
                 elif dry_run:
                     print(task)

--- a/workflow/exceptions.py
+++ b/workflow/exceptions.py
@@ -26,3 +26,9 @@ class ResourceNotFound(Exception):
 
 class NonUniqueTask(Exception):
     pass
+
+class ShellError(Exception):
+    def __init__(self, exit_code):
+        self.exit_code = exit_code
+    def __str__(self):
+        return "Command failed with exit code %s" % self.exit_code

--- a/workflow/shell.py
+++ b/workflow/shell.py
@@ -3,6 +3,8 @@
 import subprocess
 import sys
 
+from . import exceptions
+
 def run(directory, command):
     """Run the specified shell command using Fabric-like behavior"""
     wrapped_command = "cd %s && %s" % (directory, command)
@@ -12,4 +14,4 @@ def run(directory, command):
     )
     pipe.communicate()
     if pipe.returncode != 0:
-        sys.exit(pipe.returncode)
+        raise exceptions.ShellError(pipe.returncode)

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -377,6 +377,8 @@ class TaskGraph(object):
         return subgraph
 
     def _dereference_alias_helper(self, name):
+        if name is None:
+            return 
         for task in self.task_list:
             if task.alias == name:
                 return task.creates

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -547,9 +547,12 @@ class TaskGraph(object):
         for task_id, duration in self.task_durations.iteritems():
             self.task_durations[task_id] = float(duration)
 
-    def save_state(self):
+    def save_state(self, override_resource_states=None):
         """Save the states of all resources (files, databases, etc). If the
-        state file hasn't been stored yet, it creates a new one.
+        state file hasn't been stored yet, it creates a new one. Can
+        optionally pass override_resource_states to set the states of
+        particular elements, which can be useful for handling keyboard
+        interrupts, for example.
         """
 
         # read all of the old storage states first, then over write
@@ -560,6 +563,11 @@ class TaskGraph(object):
         self.read_from_storage(after_resource_states, self.abs_state_path)
         for name, resource in self.resource_dict.iteritems():
             after_resource_states[name] = resource.current_state
+
+        # if override states are provided, update the resources
+        # accordingly
+        if override_resource_states:
+            after_resource_states.update(override_resource_states)
 
         self.write_to_storage(after_resource_states, self.abs_state_path)
         self.write_to_storage(self.task_durations, self.abs_duration_path)


### PR DESCRIPTION
How should this behave? Should it remove all files it has created up to the keyboard interrupt? Should it only remove the `creates` target files it is creating when the keyboard interrupt occurs?
