### PR TITLE
implement alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,10 @@ you could use this. If you have suggestions for other ideas, please
 This package ships with the `workflow` command, which embodies the
 entire command line interface for this package. This command can be
 run from the directory that contains `workflow.yaml` or any of its
-child directories.
+child directories. Output has been formatted to be as useful as
+possible, including the task names that are run, the commands that are
+run, and how long each task takes. For convenience, this information
+is also stored in `.workflow/workflow.log`.
 
 By default, running `workflow` will execute the entire workflow, or at
 least the portion of it that is "out of sync" since the last time it
@@ -297,8 +300,9 @@ workflow --export          # prints out sequence of shell commands
 ```
 
 **`--notify`.** For long-running workflows, it is convenient to be
-alerted when the entire workflow completes. The `--notify` option makes
-it possible to have logs sent to an email address specified on the
+alerted when the entire workflow completes. The `--notify` option
+makes it possible to have the last 100 lines of the
+`.workflow/workflow.log` sent to an email address specified on the
 command line.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ incorrect results, poor performance, etc.) in the analysis and improve
 them piece by piece after the entire workflow has been written the
 first time.
 
-This packages is deliberately intended to help users write small, but
+This package is deliberately intended to help users write small, but
 compact workflow prototypes using whatever tools they prefer (R,
 pandas, scipy, hadoop) but with the explicit goal of encouraging users
 to write small scripts that produce intermediate output.
@@ -296,13 +296,13 @@ into conflicts.
 workflow --export          # prints out sequence of shell commands
 ```
 
-**`--alert`.** For long-running workflows, it is convenient to be
-alerted when the entire workflow completes. The `--alert` option makes
+**`--notify`.** For long-running workflows, it is convenient to be
+alerted when the entire workflow completes. The `--notify` option makes
 it possible to have logs sent to an email address specified on the
 command line.
 
 ```bash
-workflow --alert j.doe@example.com
+workflow --notify j.doe@example.com
 ```
 
 **autocomplete.** Autocompletion of available options with workflow is

--- a/README.md
+++ b/README.md
@@ -296,6 +296,15 @@ into conflicts.
 workflow --export          # prints out sequence of shell commands
 ```
 
+**`--alert`.** For long-running workflows, it is convenient to be
+alerted when the entire workflow completes. The `--alert` option makes
+it possible to have logs sent to an email address specified on the
+command line.
+
+```bash
+workflow --alert j.doe@example.com
+```
+
 **autocomplete.** Autocompletion of available options with workflow is
 enabled by @kislyuk's amazing
 [autocomplete](https://github.com/kislyuk/argcomplete) package. Follow

--- a/bin/workflow
+++ b/bin/workflow
@@ -15,6 +15,7 @@ import argcomplete
 from workflow.parser import get_available_tasks, get_available_archives
 from workflow.commands import execute, clean, archive
 from workflow.exceptions import CommandLineException, ConfigurationNotFound
+from workflow.alert import alert
 
 # setup the option parser
 parser = argparse.ArgumentParser(
@@ -32,14 +33,14 @@ except ConfigurationNotFound:
     available_tasks = []
 parser.add_argument(
     'task_id',
-    metavar='task',
+    metavar='TASK',
     type=str,
     choices=available_tasks,
     nargs='?', # '*', this isn't working for some reason
     help='Specify a particular task to run.',
 )
 
-# can only specify one of --force or --dry-run
+# add a bunch of keyword arguments
 parser.add_argument(
     '-f', '--force',
     action="store_true",
@@ -61,12 +62,17 @@ parser.add_argument(
     action="store_true",
     help="Export shell script instead of running the workflow.",
 )
-
-# can only specify one of --clean or --force-clean
 parser.add_argument(
     '-c', '--clean',
     action="store_true",
     help="Confirm before removing all `creates` targets defined in workflow.",
+)
+parser.add_argument(
+    '--alert',
+    type=str,
+    metavar='EMAIL',
+    nargs=1,
+    help='Specify an email address to alert on completion',
 )
 
 # Here are a few handy commands for backing up a workflow and
@@ -93,6 +99,7 @@ group.add_argument(
 # use argcomplete to autocomplete options, the parse arguments and run
 argcomplete.autocomplete(parser)
 args = parser.parse_args()
+
 try:
     if args.clean:
         clean(task_id=args.task_id, force=args.force, export=args.export)
@@ -106,3 +113,6 @@ try:
 except CommandLineException, e:
     print(e)
     sys.exit(1)
+
+if args.alert:
+    alert(*args.alert)

--- a/bin/workflow
+++ b/bin/workflow
@@ -15,7 +15,7 @@ import argcomplete
 from workflow.parser import get_available_tasks, get_available_archives
 from workflow.commands import execute, clean, archive
 from workflow.exceptions import CommandLineException, ConfigurationNotFound
-from workflow.alert import alert
+from workflow.notify import notify
 
 # setup the option parser
 parser = argparse.ArgumentParser(
@@ -68,11 +68,11 @@ parser.add_argument(
     help="Confirm before removing all `creates` targets defined in workflow.",
 )
 parser.add_argument(
-    '--alert',
+    '--notify',
     type=str,
     metavar='EMAIL',
     nargs=1,
-    help='Specify an email address to alert on completion',
+    help='Specify an email address to notify on completion',
 )
 
 # Here are a few handy commands for backing up a workflow and
@@ -114,5 +114,5 @@ except CommandLineException, e:
     print(e)
     sys.exit(1)
 
-if args.alert:
-    alert(*args.alert)
+if args.notify:
+    notify(*args.notify)

--- a/bin/workflow
+++ b/bin/workflow
@@ -9,6 +9,7 @@ import sys
 import os
 import ConfigParser
 import types
+import traceback
 
 import argcomplete
 
@@ -112,7 +113,6 @@ try:
                 export=args.export)
 except CommandLineException, e:
     print(e)
-    sys.exit(1)
-
-if args.notify:
-    notify(*args.notify)
+finally:
+    if args.notify:
+        notify(*args.notify)

--- a/workflow/alert.py
+++ b/workflow/alert.py
@@ -1,0 +1,26 @@
+import smtplib
+from email.mime.text import MIMEText
+import socket
+
+def alert(*contact_list):
+    """Send an alert to any email addresses specified in contact_list.
+    """
+    # this takes heavy inspiration from
+    # http://docs.python.org/2/library/email-examples.html
+
+    # Open a plain text file for reading.  For this example, assume that
+    # the text file contains only ASCII characters.
+    msg = MIMEText((
+        "workflow finished. yippee!"
+    ))
+
+    # fill out the relevant header information
+    msg['Subject'] = 'workflow finished'
+    msg['From'] = 'root@localhost'
+    msg['To'] = ', '.join(contact_list)
+
+    # Send the message via our own SMTP server, but don't include the
+    # envelope header.
+    server = smtplib.SMTP('localhost')
+    server.sendmail(msg['From'], contact_list, msg.as_string())
+    server.quit()

--- a/workflow/colors.py
+++ b/workflow/colors.py
@@ -1,5 +1,6 @@
 """Inspiration from https://github.com/fabric/fabric/blob/master/fabric/colors.py
 """
+import re
 
 def _wrap_with(code, bold=False):
 
@@ -25,3 +26,8 @@ bold_blue = _wrap_with('34', True)
 bold_magenta = _wrap_with('35', True)
 bold_cyan = _wrap_with('36', True)
 bold_white = _wrap_with('37', True)
+
+# regular expression to omit colorcodes
+def colorless(text):
+    """Remove color from the text"""
+    return re.sub("\033\[(1;)?[\d]+m", '', text)

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -24,13 +24,13 @@ def clean(task_id=None, force=False, export=False, pause=0.5):
     # print a warning message before removing all tasks. Briefly
     # pause to make sure user sees the message at the top.
     if not (force or export):
-        print(colors.red(
+        task_graph.logger.info(colors.red(
             "Please confirm that you want to delete the following files."
         ))
         time.sleep(pause)
         for task in task_list:
             if not task.is_pseudotask():
-                print(task.creates_message())
+                task_graph.logger.info(task.creates_message())
         yesno = raw_input(colors.red("Delete aforementioned files? [Y/n] "))
         if yesno == '':
             yesno = 'y'
@@ -76,7 +76,9 @@ def execute(task_id=None, force=False, dry_run=False, export=False):
         if export:
             print("cd %s" % task_graph.root_directory)
         else:
-            print(task_graph.duration_message(out_of_sync_tasks))
+            task_graph.logger.info(
+                task_graph.duration_message(out_of_sync_tasks)
+            )
         for task in task_graph.iter_bfs(out_of_sync_tasks):
             # We unfortunately need (?) to re-run in_sync here in case
             # things change during the course of a run. This is not
@@ -100,16 +102,20 @@ def execute(task_id=None, force=False, dry_run=False, export=False):
                         )
                         sys.exit(getattr(e, 'exit_code', 1))
                 elif dry_run:
-                    print(task)
+                    task_graph.logger.info(task)
                 elif export:
-                    print(task.command_message(color=None, pre=""))
+                    task_graph.logger.info(
+                        task.command_message(color=None, pre="")
+                    )
         
     # if no tasks were executed, then alert the user that nothing
     # needed to be run
     else:
-        print("No tasks are out of sync in the workflow defined in '%s'" % (
-            os.path.relpath(task_graph.config_path, os.getcwd())
-        ))
+        task_graph.logger.info(
+            "No tasks are out of sync in the workflow defined in '%s'" % (
+                os.path.relpath(task_graph.config_path, os.getcwd())
+            )
+        )
         
     # otherwise, we need to recalculate hashes for everything that is
     # out of sync

--- a/workflow/commands.py
+++ b/workflow/commands.py
@@ -43,6 +43,10 @@ def clean(task_id=None, force=False, export=False, pause=0.5):
         print("cd %s" % task_graph.root_directory)
     task_graph.clean(export=export, task_list=task_list)
 
+    # mark the task_graph as completing successfully to send the
+    # correct email message
+    task_graph.successful = True
+
 def execute(task_id=None, force=False, dry_run=False, export=False):
     """Execute the task workflow.
     """
@@ -122,6 +126,10 @@ def execute(task_id=None, force=False, dry_run=False, export=False):
     if not (dry_run or export):
         task_graph.save_state()
 
+    # mark the task_graph as completing successfully to send the
+    # correct email message
+    task_graph.successful = True
+
 def archive(backup=False, restore=False):
     """Interact with archives of the workflow, by either backing it up or
     restoring it from a previous backup.
@@ -139,3 +147,7 @@ def archive(backup=False, restore=False):
     # anything.
     if restore:
         task_graph.restore_archive(restore)
+
+    # mark the task_graph as completing successfully to send the
+    # correct email message
+    task_graph.successful = True

--- a/workflow/exceptions.py
+++ b/workflow/exceptions.py
@@ -14,20 +14,20 @@ class ConfigurationNotFound(CommandLineException):
             self.cwd,
         )
 
-class InvalidTaskDefinition(Exception):
+class InvalidTaskDefinition(CommandLineException):
     pass
 
-class ResourceNotFound(Exception):
+class ResourceNotFound(CommandLineException):
     def __init__(self, resource):
         self.resource = resource
 
     def __str__(self):
         return "\nResource '%s' not found" % self.resource
 
-class NonUniqueTask(Exception):
+class NonUniqueTask(CommandLineException):
     pass
 
-class ShellError(Exception):
+class ShellError(CommandLineException):
     def __init__(self, exit_code):
         self.exit_code = exit_code
     def __str__(self):

--- a/workflow/logger.py
+++ b/workflow/logger.py
@@ -1,0 +1,39 @@
+"""This module sets up logging to split output to terminal and to
+file, which can be convenient for inspecting long-running jobs and for
+sending notifications with useful content
+"""
+
+import logging
+
+from .colors import colorless
+
+class ColorlessFileHandler(logging.FileHandler):
+    def emit(self, record):
+        record.msg = colorless(record.msg)
+        return super(ColorlessFileHandler, self).emit(record)
+
+def configure(task_graph):
+    logger = logging.getLogger('workflow')
+    logger.setLevel(logging.DEBUG)
+
+    # create file handler and a console handler. the console
+    # handler writes to stderr by default
+    file_handler = ColorlessFileHandler(task_graph.abs_log_path, mode='w')
+    console_handler = logging.StreamHandler()
+
+    # set the logging levels on these handlers
+    file_handler.setLevel(logging.DEBUG)
+    console_handler.setLevel(logging.DEBUG)
+
+    # create formatter and add it to the handlers
+    formatter = logging.Formatter('%(message)s')
+    console_handler.setFormatter(formatter)
+    file_handler.setFormatter(formatter)
+
+    # add the handlers to logger
+    logger.addHandler(console_handler)
+    logger.addHandler(file_handler)
+
+
+    return logger
+

--- a/workflow/notify.py
+++ b/workflow/notify.py
@@ -14,7 +14,7 @@ def notify(*contact_list):
     # set the subject to notify about success/failure on this
     # particular host
     task_graph = load_task_graph()
-    status = 'failed'
+    status = 'FAILED'
     if task_graph.successful:
         status = 'successfully finished'
 

--- a/workflow/notify.py
+++ b/workflow/notify.py
@@ -2,16 +2,25 @@ import smtplib
 from email.mime.text import MIMEText
 import socket
 
-def alert(*contact_list):
-    """Send an alert to any email addresses specified in contact_list.
+def notify(*contact_list):
+    """Send an notification to any email addresses specified in
+    contact_list.
+
     """
     # this takes heavy inspiration from
     # http://docs.python.org/2/library/email-examples.html
 
-    # Open a plain text file for reading.  For this example, assume that
-    # the text file contains only ASCII characters.
+    # TODO: switch to using loggin instead of print() statements so
+    # that we can have output logged to a file in the .workflow
+    # directory and also have output logged to the terminal
+
+    # TODO: for now, read the last 100 lines of the log and put it in
+    # the email. it may also be useful to include other meta
+    # information, such as the commands that were run or the total
+    # time it took
+
     msg = MIMEText((
-        "workflow finished. yippee!"
+        "XXXX workflow finished. yippee!"
     ))
 
     # fill out the relevant header information

--- a/workflow/shell.py
+++ b/workflow/shell.py
@@ -2,15 +2,17 @@
 """
 import subprocess
 import sys
+import logging
 
 from . import exceptions
 
 def run(directory, command):
     """Run the specified shell command using Fabric-like behavior"""
+    # TODO get logging to work in here, too
     wrapped_command = "cd %s && %s" % (directory, command)
     pipe = subprocess.Popen(
         wrapped_command, shell=True, 
-        stdout=sys.stdout, stderr=sys.stderr
+        stdout=sys.stdout, stderr=sys.stderr,
     )
     pipe.communicate()
     if pipe.returncode != 0:

--- a/workflow/shell.py
+++ b/workflow/shell.py
@@ -3,17 +3,43 @@
 import subprocess
 import sys
 import logging
+import threading
 
 from . import exceptions
 
+def log_output(stream):
+    # this function logs the output from the subprocess'ed command.
+    #
+    # TODO: this works for all outputs that do not backspace. Note
+    # what happens when you run the workflow in examples/reuters-tfidf
+    # when curl is running
+    logger = logging.getLogger('workflow')
+    for line in iter(stream.readline, ''):
+        logger.info(line.rstrip('\n'))
+    stream.close()
+
 def run(directory, command):
-    """Run the specified shell command using Fabric-like behavior"""
-    # TODO get logging to work in here, too
+    """Run the specified shell command using Fabric-like behavior."""
+
+    # combine stderr and stdout output when running command so we can
+    # stream output to the logger for output to terminal and file
+    # simultaneously
     wrapped_command = "cd %s && %s" % (directory, command)
     pipe = subprocess.Popen(
         wrapped_command, shell=True, 
-        stdout=sys.stdout, stderr=sys.stderr,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
     )
-    pipe.communicate()
+
+    # this uses threading to capture the output in real time in a
+    # non-blocking way and use the log_output function to report the
+    # output using the logging module. This framework takes
+    # inspiration from http://stackoverflow.com/a/4985080/564709
+    thread = threading.Thread(target=log_output, args=(pipe.stdout,))
+    thread.daemon = True
+    thread.start()
+    thread.join()
+    pipe.wait()
+
+    # if pipe is busted, raise an error
     if pipe.returncode != 0:
         raise exceptions.ShellError(pipe.returncode)

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -6,7 +6,6 @@ import StringIO
 import collections
 import datetime
 import glob
-import logging
 
 import jinja2
 
@@ -14,6 +13,7 @@ from .exceptions import InvalidTaskDefinition, ResourceNotFound, NonUniqueTask
 from . import colors
 from . import shell
 from . import resources
+from . import logger
 
 class Task(resources.base.BaseResource):
 
@@ -274,36 +274,11 @@ class TaskGraph(object):
         self.task_durations = {}
 
         # instantiate the logger instance for this workflow
-        self.logger = self._configure_logger()
+        self.logger = logger.configure(self)
 
         # the success status is used for managing notification emails
         # in an intelligent way
         self.successful = False
-
-    def _configure_logger(self):
-        logger = logging.getLogger('workflow')
-        logger.setLevel(logging.DEBUG)
-
-        # create file handler and a console handler. the console
-        # handler writes to stderr by default
-        file_handler = logging.FileHandler(self.abs_log_path, mode='w')
-        file_handler.setLevel(logging.DEBUG)
-        console_handler = logging.StreamHandler()
-        console_handler.setLevel(logging.DEBUG)
-
-        # TODO: strip out color codes in stream handler somehow? maybe
-        # with filters? maybe by associating color codes to particular
-        # log levels?
-
-        # create formatter and add it to the handlers
-        formatter = logging.Formatter('%(message)s')
-        console_handler.setFormatter(formatter)
-        file_handler.setFormatter(formatter)
-
-        # add the handlers to logger
-        logger.addHandler(console_handler)
-        logger.addHandler(file_handler)
-        return logger
 
     def _iter_helper(self, tasks, popmethod, updownstream):
         horizon = collections.deque(tasks)

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -6,6 +6,7 @@ import StringIO
 import collections
 import datetime
 import glob
+import logging
 
 import jinja2
 
@@ -148,7 +149,7 @@ class Task(resources.base.BaseResource):
         """Remove the specified target"""
         if not self.is_pseudotask():
             self.run(self.clean_command())
-            print("removed %s" % self.creates_message())
+            self.graph.logger.info("removed %s" % self.creates_message())
 
     def execute(self, command=None):
         """Run the specified task from the root of the workflow"""
@@ -160,7 +161,7 @@ class Task(resources.base.BaseResource):
             # useful message about starting this task and what it is
             # called so users know how to re-call this task if they
             # notice something fishy during execution.
-            print(self.creates_message())
+            self.graph.logger.info(self.creates_message())
 
             # start a timer so we can keep track of how long this task
             # executes. Its important that we're timing watch time, not
@@ -180,15 +181,14 @@ class Task(resources.base.BaseResource):
         # the command. This takes inspiration from how
         # fabric.operations.local works http://bit.ly/1dQEgjl
         else:
-            print(self.command_message(command=command))
-            sys.stdout.flush()
+            self.graph.logger.info(self.command_message(command=command))
             self.run(command)
 
         # stop the clock and alert the user to the clock time spent
         # exeucting the task
         if start_time:
             self.duration = time.time() - start_time
-            print(self.duration_message())
+            self.graph.logger.info(self.duration_message())
 
             # store the duration on the graph object
             self.graph.task_durations[self.id] = self.duration
@@ -255,6 +255,7 @@ class TaskGraph(object):
     # relative location of various storage locations
     state_path = os.path.join(".workflow", "state.csv")
     duration_path = os.path.join(".workflow", "duration.csv")
+    log_path = os.path.join(".workflow", "workflow.log")
     archive_dir = os.path.join(".workflow", "archive")
 
     def __init__(self, config_path):
@@ -271,6 +272,34 @@ class TaskGraph(object):
 
         # store the time that this task takes
         self.task_durations = {}
+
+        # instantiate the logger instance for this workflow
+        self.logger = self._configure_logger()
+
+    def _configure_logger(self):
+        logger = logging.getLogger('workflow')
+        logger.setLevel(logging.DEBUG)
+
+        # create file handler and a console handler. the console
+        # handler writes to stderr by default
+        file_handler = logging.FileHandler(self.abs_log_path, mode='w')
+        file_handler.setLevel(logging.DEBUG)
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(logging.DEBUG)
+
+        # TODO: strip out color codes in stream handler somehow? maybe
+        # with filters? maybe by associating color codes to particular
+        # log levels?
+
+        # create formatter and add it to the handlers
+        formatter = logging.Formatter('%(message)s')
+        console_handler.setFormatter(formatter)
+        file_handler.setFormatter(formatter)
+
+        # add the handlers to logger
+        logger.addHandler(console_handler)
+        logger.addHandler(file_handler)
+        return logger
 
     def _iter_helper(self, tasks, popmethod, updownstream):
         horizon = collections.deque(tasks)
@@ -459,7 +488,7 @@ class TaskGraph(object):
         task_list = task_list or self.task_list
         for task in task_list:
             if export:
-                print(task.clean_command())
+                self.logger.info(task.clean_command())
             else:
                 task.clean()
         if os.path.exists(self.abs_state_path) and task_list == self.task_list:
@@ -507,6 +536,11 @@ class TaskGraph(object):
     def abs_duration_path(self):
         """Convenience property for accessing duration storage location"""
         return os.path.join(self.root_directory, self.duration_path)
+
+    @property
+    def abs_log_path(self):
+        """Convenience property for accessing log storage location"""
+        return os.path.join(self.root_directory, self.log_path)
 
     @property
     def abs_archive_dir(self):
@@ -602,8 +636,7 @@ class TaskGraph(object):
 
         # create the archive
         command = "tar cjf %s %s" % (archive_name, ' '.join(all_filenames))
-        print(colors.bold_white(command))
-        sys.stdout.flush()
+        self.logger.info(colors.bold_white(command))
         shell.run(self.root_directory, command)
 
     def restore_archive(self, archive):
@@ -613,8 +646,7 @@ class TaskGraph(object):
         """
         archive_name = os.path.join(self.root_directory, archive)
         command = "tar xjf %s" % archive_name
-        print(colors.bold_white(command))
-        sys.stdout.flush()
+        self.logger.info(colors.bold_white(command))
         shell.run(self.root_directory, command)
 
     def get_available_archives(self):

--- a/workflow/tasks.py
+++ b/workflow/tasks.py
@@ -276,6 +276,10 @@ class TaskGraph(object):
         # instantiate the logger instance for this workflow
         self.logger = self._configure_logger()
 
+        # the success status is used for managing notification emails
+        # in an intelligent way
+        self.successful = False
+
     def _configure_logger(self):
         logger = logging.getLogger('workflow')
         logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
system, email, and twitter seem best. SMS?

```
# system alert. bell rings, notifications, etc
workflow --alert 

# twitter alerts
workflow --alert @deanmalmgren

# email alerts
workflow --alert dean.malmgren@datascopeanalytics.com
```

Should it be possible to specify this from the YAML configuration, either on a per-task basis or on a workflow basis? Per-task basis might look something like this:

``` yaml

---
creates: data/pdf.csv
depends: 
  - src/pdf.py
  - data/raw.dat
command: python {{depends|join(' ')}} > {{creates}}
alert: @deanmalmgren
```

Workflow basis might change the overall organization of the YAML to have a `tasks` key in addition to an `alert` key (and any other configuration options that are useful:

``` yaml
alert: @deanmalmgren # received when entire workflow is complete
tasks:
  ---
  creates: data/pdf.csv
  depends: 
    - src/pdf.py
    - data/raw.dat
  command: python {{depends|join(' ')}} > {{creates}}
```
