### PR TITLE
Can't use variable names in the create block

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,37 @@ tasks:
     command: python {{depends[0]}} {{sigma}} < {{depends[1]}} > {{creates}}
 ```
 
+Another common use case for global variables is when you have several
+tasks that all depend on the same file. You can also use jinja
+templating in the `creates` and `depends` attributes of your
+`workflow.yaml` like this:
+
+```yaml
+---
+input: data/sp500.html
+tasks:
+  -
+    creates: "{{input}}"
+	command:
+	  - mkdir -p $(dirname {{creates}})
+      - wget http://en.wikipedia.org/wiki/List_of_S%26P_500_companies -O {{creates}}
+  -
+	creates: data/names.dat
+	depends:
+      - src/extract_names.py
+      - "{{input}}"
+	command: python {{depends|join(' ')}} > {{creates}}
+  -
+	creates: data/symbols.dat
+	depends:
+      - src/extract_symbols.py
+      - "{{input}}"
+	command: python {{depends|join(' ')}} > {{creates}}
+```
+
 There are several [examples](examples/) for more inspiration on how
-you could use this. If you have suggestions for other ideas, please
-[add them](issues)!
+you could use the workflow.yaml specification. If you have suggestions
+for other ideas, please [add them](issues)!
 
 ### command line interface
 

--- a/examples/sp500/workflow.yaml
+++ b/examples/sp500/workflow.yaml
@@ -5,7 +5,7 @@ input_name: data/sp500.html
 tasks:
 # create some data to analyze.
   -
-    creates: data/sp500.html
+    creates: "{{input_name}}"
     command:
       - mkdir -p $(dirname {{creates}})
       - wget http://en.wikipedia.org/wiki/List_of_S%26P_500_companies -O {{creates}}
@@ -16,5 +16,5 @@ tasks:
     creates: data/sp500.csv
     depends: 
       - code/parse_sp500.py
-      - get_data
-    command: python {{depends[0]}} data/sp500.html > {{creates}}
+      - "{{input_name}}"
+    command: python {{depends|join(' ')}} > {{creates}}


### PR DESCRIPTION
The following code produces an error.

```

---
input_name: some/stupid/filename.txt

tasks:

  -
    creates: {{input_name}}
    command:
      - mkdir -p $(dirname {{creates}})
      - wget http://en.wikipedia.org/wiki/List_of_S%26P_500_companies -O {{creates}}
    alias: get_data
```

Traceback (most recent call last):
  File "/usr/local/bin/workflow", line 7, in <module>
    execfile(**file**)
  File "/Users/aaron/src/workflow/bin/workflow", line 30, in <module>
    available_tasks = get_available_tasks()
  File "/Users/aaron/src/workflow/workflow/parser.py", line 86, in get_available_tasks
    task_graph = load_task_graph()
  File "/Users/aaron/src/workflow/workflow/parser.py", line 56, in load_task_graph
    for i, yaml_obj in enumerate(config_yaml):
  File "/Library/Python/2.7/site-packages/yaml/**init**.py", line 83, in load_all
    yield loader.get_data()
  File "/Library/Python/2.7/site-packages/yaml/constructor.py", line 33, in get_data
    return self.construct_document(self.get_node())
  File "/Library/Python/2.7/site-packages/yaml/constructor.py", line 48, in construct_document
    for dummy in generator:
  File "/Library/Python/2.7/site-packages/yaml/constructor.py", line 398, in construct_yaml_map
    value = self.construct_mapping(node)
  File "/Library/Python/2.7/site-packages/yaml/constructor.py", line 208, in construct_mapping
    return BaseConstructor.construct_mapping(self, node, deep=deep)
  File "/Library/Python/2.7/site-packages/yaml/constructor.py", line 132, in construct_mapping
    "found unacceptable key (%s)" % exc, key_node.start_mark)
yaml.constructor.ConstructorError: while constructing a mapping
  in "<string>", line 17, column 14:
        creates: {{input_name}}
                 ^
found unacceptable key (unhashable type: 'dict')
  in "<string>", line 17, column 15:
        creates: {{input_name}}
