### PR TITLE
--only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,14 @@ tasks between two specified tasks like this:
 flo run --start-at=path/to/some/file.txt path/to/some/output/file.txt
 ```
 
+If you ever want to only run one task, say a task that creates
+`path/to/some/file.txt`, you can specify that task as both the
+starting and ending point of the workflow run:
+
+```bash
+flo run --start-at=path/to/some/file.txt path/to/some/file.txt
+```
+
 ##### flo run --skip task_id
 
 In some situations --- especially with very long-running tasks ---

--- a/examples/run_functional_tests.sh
+++ b/examples/run_functional_tests.sh
@@ -80,5 +80,19 @@ exit_code=$(expr ${exit_code} + $?)
 sed -i 's/\+2/+1/g' flo.yaml
 cd $BASEDIR
 
+# test the --only option
+cd $BASEDIR/hello-world
+flo run -f
+flo run --only data/hello_world.txt
+grep "No tasks are out of sync" .flo/flo.log > /dev/null
+exit_code=$(expr ${exit_code} + $?)
+flo run -f --only data/hello_world.txt
+n_matches=$(grep "|-> " .flo/flo.log | wc -l)
+if [[ ${n_matches} -ne 2 ]]; then
+    red "flo run -f --only data/hello_world.txt should only run two commands"
+    exit_code=$(expr ${exit_code} + 1)
+fi
+cd $BASEDIR
+
 # exit with the sum of the status
 exit ${exit_code}

--- a/flo/tasks/graph.py
+++ b/flo/tasks/graph.py
@@ -168,6 +168,8 @@ class TaskGraph(object):
                 downstream = False
             node = start or end
             tasks = self.iter_graph([node], downstream=downstream)
+        elif start == end:
+            tasks = [start]
         else:
             graph = self.get_networkx_graph()
             tasks = set()

--- a/run_travis_tests.py
+++ b/run_travis_tests.py
@@ -8,7 +8,7 @@ import subprocess
 
 import yaml
 
-from workflow.colors import green, red
+from flo.colors import green, red
 
 root_dir = os.path.dirname(os.path.abspath(__file__))
 def run_test(command):


### PR DESCRIPTION
Related to #36, but sometimes you only want to run a specific task, regardless of whether its upstream dependencies are out of sync. This also would have addressed our situation from time to time, right @bo-peng?
