### PR TITLE
make N-M range clearer

### DIFF
--- a/flo/tasks/graph.py
+++ b/flo/tasks/graph.py
@@ -299,13 +299,16 @@ class TaskGraph(object):
                     n_unknown += 1
         msg = ''
         if n_unknown > 0:
-            msg += "%d new tasks with unknown durations.\n" % (
+            msg += "There are %d new tasks with unknown durations.\n" % (
                 n_unknown,
             )
-        msg += "The remaining %d-%d tasks need to be executed,\n" % (
-            len(tasks),
-            n_tasks,
-        )
+        if len(tasks) == n_tasks:
+            msg += "The remaining %d tasks need to be executed,\n" % n_tasks
+        else:
+            msg += "The remaining %d to %d tasks need to be executed,\n" % (
+                len(tasks),
+                n_tasks,
+            )
         if max_duration == min_duration == 0.0:
             msg += "which will take an indeterminate amount of time."
         elif max_duration == min_duration:


### PR DESCRIPTION
Right now the message like `1-2 tasks will be executed` could refer to "one of two tasks" or "between one to two tasks will be executed". Need to clarify the message a bit.

Also, as @laurieskelly pointed out, when N==M, should just show one number to remove the ambiguity.
