### PR TITLE
flo should confirm that `creates` exists after a task is run

### DIFF
--- a/flo/resources/base.py
+++ b/flo/resources/base.py
@@ -114,3 +114,7 @@ class BaseResource(object):
         raise NotImplementedError(
             "Must implement get_filename for child classes"
         )
+
+    def exists(self):
+        """Check to see if the resource exists."""
+        raise NotImplementedError

--- a/flo/resources/file_system.py
+++ b/flo/resources/file_system.py
@@ -43,3 +43,6 @@ class FileSystem(BaseResource):
 
     def get_filename(self):
         return self.name
+
+    def exists(self):
+        return os.path.exists(self.resource_path)

--- a/flo/tasks/task.py
+++ b/flo/tasks/task.py
@@ -3,7 +3,7 @@ import time
 import StringIO
 import copy
 
-from ..exceptions import InvalidTaskDefinition
+from ..exceptions import InvalidTaskDefinition, CommandLineException
 from .. import colors
 from .. import shell
 from .. import resources
@@ -239,6 +239,14 @@ class Task(resources.base.BaseResource):
         for command in self.command_list:
             self.graph.logger.info(self.command_message(command))
             self.run(command)
+
+        # confirm that the creates resources exists on the filesystem
+        if not all(resource.exists() for resource in self.creates_resources):
+            raise CommandLineException(self.creates + (
+                " does not exist after running the previous commands. "
+                "Double check the syntax to confirm that these commands "
+                "will actually create it."
+            ))
 
         # stop the clock and alert the user to the clock time spent
         # running the task


### PR DESCRIPTION
This came up with @stringertheory modified #58 and inadvertently did something like this:

``` yaml

---
creates: a_file.txt
command: echo "hello world" > {{creates[0]}} # creates file called a

---
creates: b_file.txt
command: echo "hello world" > {{creates[1]}} # creates file called _
```

flo should detect when a `creates` isn't actually created and throw an error.
