### PR TITLE
more informative error if someone tries to define creates as a list

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ track version numbers, where backwards incompatible changes
 latest
 ------
 
+* more informative error messages (#58)
 
 1.0.0
 -----

--- a/docs/yaml_specification.rst
+++ b/docs/yaml_specification.rst
@@ -15,22 +15,46 @@ something like this:
     depends: "path/to/some/script.py"
     command: "python {{depends}} > {{creates}}"
 
-Every task YAML object must have a :ref:`yaml-creates` key and can
-optionally contain :ref:`yaml-depends` and :ref:`yaml-command`
-keys. The order of these keys does not matter; the above order is
-chosen for explanatory purposes only.
+Every YAML object that defines a task must have :ref:`yaml-creates`
+and :ref:`yaml-command` keys and can optionally contain a
+:ref:`yaml-depends` key. The order of these keys does not matter; the
+above order is chosen for explanatory purposes only.
 
 .. _yaml-creates:
 
 creates
 '''''''
 
-The ``creates`` key defines the resource that is created. By default,
-it is interpreted as a path to a file (relative paths are interpreted
-as relative to the ``flo.yaml`` file). You can also specify a
-protocol, such as ``mysql:database/table`` (`yet-to-be-implemented
-<http://github.com/deanmalmgren/flo/issues/15>`__), for non-file based
-resources.
+The ``creates`` key uniquely identifies the resource that is
+created. By default, it is interpreted as a path to a file (relative
+paths are interpreted as relative to the ``flo.yaml`` file) or a
+directory. Importantly, every task is intended to create a single file
+or directory. If you have a task that creates multiple files, you can
+either (i) split that into separate tasks or (ii) have all of those
+files embedded in a directory and use the directory name as the
+``creates`` value like this:
+
+.. code-block:: yaml
+
+   ---
+   creates: "path/to/output/directory"
+   depends: "path/to/some/script.py"
+   command:
+     - "mkdir -p {{creates}}"
+     - "python {{depends}} {{creates}}"
+
+In this case, the directory ``path/to/output/directory`` is passed as
+the first argument to ``path/to/some/script.py``, which can then add
+as many files as necessary to that directory. When this task is
+complete, ``flo`` checks the hash of all files in
+``path/to/output/directory`` and all of its child directories to
+determine if it is in sync or not.
+
+..
+   You can also specify a
+   protocol, such as ``mysql:database/table`` (`yet-to-be-implemented
+   <http://github.com/deanmalmgren/flo/issues/15>`__), for non-file based
+   resources.
 
 .. _yaml-depends:
 

--- a/flo/exceptions.py
+++ b/flo/exceptions.py
@@ -1,3 +1,5 @@
+import yaml
+
 class CommandLineException(Exception):
     """convenience exception to make it easy to not print traceback when
     run from the command line
@@ -18,7 +20,13 @@ class ConfigurationNotFound(CommandLineException):
 
 
 class InvalidTaskDefinition(CommandLineException):
-    pass
+    def __init__(self, message, yaml_dict):
+        self.message = message
+        self.yaml_dict = yaml_dict
+
+    def __str__(self):
+        msg = self.message + "; offending task:"
+        return "%s\n\n%s" % (msg, yaml.dump(self.yaml_dict))
 
 
 class ResourceNotFound(CommandLineException):

--- a/flo/exceptions.py
+++ b/flo/exceptions.py
@@ -1,5 +1,6 @@
 import yaml
 
+
 class CommandLineException(Exception):
     """convenience exception to make it easy to not print traceback when
     run from the command line

--- a/flo/tasks/graph.py
+++ b/flo/tasks/graph.py
@@ -10,8 +10,7 @@ import json
 
 import networkx as nx
 
-from ..exceptions import InvalidTaskDefinition, NonUniqueTask, ShellError, \
-    CommandLineException
+from ..exceptions import NonUniqueTask, ShellError, CommandLineException
 from .. import colors
 from .. import shell
 from .. import resources

--- a/flo/tasks/task.py
+++ b/flo/tasks/task.py
@@ -36,11 +36,18 @@ class Task(resources.base.BaseResource):
         # configuration file are valid
         if self._creates is None:
             raise InvalidTaskDefinition(
-                "every task must define a `creates`"
+                "every task must define a `creates`",
+                self.yaml_data,
+            )
+        if not isinstance(self._creates, (str, unicode)):
+            raise InvalidTaskDefinition(
+                "each task must define a single `creates` as a string",
+                self.yaml_data,
             )
         if self._command is None:
             raise InvalidTaskDefinition(
-                "every task must define a `command`"
+                "every task must define a `command`",
+                self.yaml_data,
             )
 
         # remember other attributes of this Task for rendering

--- a/provision/debian.sh
+++ b/provision/debian.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 
-# get the base directory name of this file
-# http://stackoverflow.com/a/11114547/564709
-sudo apt-get install -y realpath
-base=$(dirname $(realpath $0))/..
+# this needs to work both for vagrant provisioning and for travis
+# builds in a python virtualenv. in the virtual machine provisioning,
+# we're passing the directory this should be run from. in travis-ci,
+# its run from the root of the repository.
+if [ "$#" -eq 1 ]; then
+    cd $1
+    base=$(pwd)
+else
+    # get the base directory name of this file so it works in
+    # travis-ci environment http://stackoverflow.com/a/11114547/564709
+    sudo apt-get install -y realpath
+    base=$(dirname $(realpath $0))/..
+fi
 
 # install all of the dependencies required in the examples
-sed 's/\(.*\)\#.*/\1/' < $base/examples/DEBIAN | xargs sudo apt-get install -y
+sed 's/\(.*\)\#.*/\1/' < $base/examples/DEBIAN | xargs sudo apt-get install -y --fix-missing

--- a/provision/debian.sh
+++ b/provision/debian.sh
@@ -15,4 +15,5 @@ else
 fi
 
 # install all of the dependencies required in the examples
+sudo apt-get update
 sed 's/\(.*\)\#.*/\1/' < $base/examples/DEBIAN | xargs sudo apt-get install -y --fix-missing


### PR DESCRIPTION
One of the first things that @stringertheory tried was to create a list of targets that are created by the same task.
- [ ] give an informative error message when a `creates` is a list
- [ ] describe how to create multiple files in a script in the documentation
