### PR TITLE
throw better errors when YAML isn't valid

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ track version numbers, where backwards incompatible changes
 latest
 ------
 
-* more informative error messages (#58)
+* more informative error messages (#57, #58)
 
 1.0.0
 -----

--- a/flo/commands/__init__.py
+++ b/flo/commands/__init__.py
@@ -46,6 +46,6 @@ def run_subcommand(args):
     command = args.__dict__.pop("command")
     try:
         command.execute(**args.__dict__)
-    except CommandLineException, e:
-        print(colors.red(e))
-        sys.exit(getattr(e, 'exit_code', 1))
+    except CommandLineException, error:
+        print(colors.red(error))
+        sys.exit(getattr(error, 'exit_code', 1))

--- a/flo/commands/base.py
+++ b/flo/commands/base.py
@@ -1,5 +1,5 @@
 from ..parser import load_task_graph, get_task_kwargs_list
-from ..exceptions import ConfigurationNotFound
+from ..exceptions import ConfigurationNotFound, YamlError
 
 
 class BaseCommand(object):
@@ -43,7 +43,7 @@ class BaseCommand(object):
     def task_kwargs_list(self):
         try:
             return get_task_kwargs_list(config=self.config)
-        except ConfigurationNotFound:
+        except (ConfigurationNotFound, YamlError):
             return []
 
     @property

--- a/flo/commands/run.py
+++ b/flo/commands/run.py
@@ -56,7 +56,7 @@ class Command(BaseCommand):
         super(Command, self).execute(**kwargs)
         try:
             self.inner_execute(task_id, start_at, skip, only, force)
-        except CommandLineException, e:
+        except CommandLineException:
             raise
         finally:
             if notify_emails:

--- a/flo/commands/status.py
+++ b/flo/commands/status.py
@@ -41,8 +41,8 @@ class Command(RunCommand):
         print("Starting server at http://localhost:%d" % port)
         try:
             httpd = SocketServer.TCPServer(("", port), Handler)
-        except socket.error, e:
-            raise CommandLineException(e.strerror)
+        except socket.error, error:
+            raise CommandLineException(error.strerror)
         try:
             httpd.serve_forever()
         except KeyboardInterrupt:

--- a/flo/exceptions.py
+++ b/flo/exceptions.py
@@ -48,3 +48,22 @@ class ShellError(CommandLineException):
 
     def __str__(self):
         return "Command failed with exit code %s" % self.exit_code
+
+
+class YamlError(CommandLineException):
+    def __init__(self, config_filename, yaml_error):
+        self.config_filename = config_filename
+        self.yaml_error = yaml_error
+
+    def __str__(self):
+        msg = "There was an error loading your YAML configuration file "
+        msg += "located at\n%s:\n\n" % self.config_filename
+        msg += str(self.yaml_error)
+
+        # provide useful hints here for common problems
+        if "{{" in str(self.yaml_error):
+            msg += "\n\n"
+            msg += "Try quoting your jinja templates if they start with '{{'\n"
+            msg += "because YAML interprets an unquoted '{' as the start of\n"
+            msg += "a new YAML object."
+        return msg

--- a/flo/parser.py
+++ b/flo/parser.py
@@ -89,7 +89,10 @@ def get_task_kwargs_list(config=None):
     # load the data
     with open(config_path) as stream:
         config_yaml = yaml.load_all(stream.read())
-    return config_yaml2task_kwargs_list(config_yaml)
+    try:
+        return config_yaml2task_kwargs_list(config_yaml)
+    except yaml.constructor.ConstructorError, error:
+        raise exceptions.YamlError(config_path, error)
 
 
 @memoize

--- a/flo/tasks/graph.py
+++ b/flo/tasks/graph.py
@@ -377,11 +377,11 @@ class TaskGraph(object):
                 else:
                     try:
                         task.timed_run()
-                    except (KeyboardInterrupt, ShellError), e:
+                    except (KeyboardInterrupt, ShellError), error:
                         self.save_state(
                             override_resource_states={task.name: ''},
                         )
-                        sys.exit(getattr(e, 'exit_code', 1))
+                        sys.exit(getattr(error, 'exit_code', 1))
         if not mock_run:
             self.save_state()
 


### PR DESCRIPTION
Be sure to suppress traceback when YAML isn't valid and try to throw useful error messages when, for example, this happens:

``` yaml
depends: {{pi}} # pyYAML interprets this as a new object, not a string
```

This came up with @stringertheory trying to use global variables
