### PR TITLE
handle jinja templating errors in a good way

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ track version numbers, where backwards incompatible changes
 latest
 ------
 
-* more informative error messages (#58)
+* more informative error messages (#56, #58)
 
 1.0.0
 -----

--- a/flo/exceptions.py
+++ b/flo/exceptions.py
@@ -42,6 +42,18 @@ class NonUniqueTask(CommandLineException):
     pass
 
 
+class JinjaError(CommandLineException):
+    def __init__(self, error):
+        self.error = error
+
+    def __str__(self):
+        tab = "    "
+        source = self.error.source.replace('\n', '\n%s' % tab)
+        msg = "Error rendering Jinja template: %s\n\n" % self.error.message
+        msg += "Original template source:\n\n%s%s" % (tab, source)
+        return msg
+
+
 class ShellError(CommandLineException):
     def __init__(self, exit_code):
         self.exit_code = exit_code

--- a/flo/exceptions.py
+++ b/flo/exceptions.py
@@ -43,17 +43,43 @@ class NonUniqueTask(CommandLineException):
     pass
 
 
-class JinjaError(CommandLineException):
+class JinjaTemplateError(CommandLineException):
+    source_message_prefix = "Original template source"
+    error_message_prefix = "Error loading Jinja template"
+    tab = "    "
+
     def __init__(self, template_string, error):
         self.template_string = template_string
         self.error = error
 
+    def indent(self, s):
+        return self.tab + s.replace('\n', '\n%s' % self.tab)
+
+    def source_message(self):
+        source = self.indent(self.template_string)
+        return "%s:\n\n%s" % (self.source_message_prefix, source)
+
+    def error_message(self):
+        return "%s: %s\n\n" % (self.error_message_prefix, self.error.message)
+
     def __str__(self):
-        tab = "    "
-        source = self.template_string.replace('\n', '\n%s' % tab)
-        msg = "Error rendering Jinja template: %s\n\n" % self.error.message
-        msg += "Original template source:\n\n%s%s" % (tab, source)
-        return msg
+        return self.error_message() + self.source_message()
+
+
+class JinjaRenderError(JinjaTemplateError):
+    error_message_prefix = "Jinja template variable is not in context"
+
+    def __init__(self, template_string, error, **context_dict):
+        super(JinjaRenderError, self).__init__(template_string, error)
+        self.context_dict = context_dict
+
+    def __str__(self):
+        context_str = "{\n"
+        for k, v in self.context_dict.iteritems():
+            context_str += "%s%s: %s,\n" % (self.tab, k, v)
+        context_str += "}"
+        msg = "\n\nContext:\n\n%s" % self.indent(context_str)
+        return self.error_message() + self.source_message() + msg
 
 
 class ShellError(CommandLineException):

--- a/flo/exceptions.py
+++ b/flo/exceptions.py
@@ -1,4 +1,5 @@
 import yaml
+import jinja2
 
 
 class CommandLineException(Exception):
@@ -43,12 +44,13 @@ class NonUniqueTask(CommandLineException):
 
 
 class JinjaError(CommandLineException):
-    def __init__(self, error):
+    def __init__(self, template_string, error):
+        self.template_string = template_string
         self.error = error
 
     def __str__(self):
         tab = "    "
-        source = self.error.source.replace('\n', '\n%s' % tab)
+        source = self.template_string.replace('\n', '\n%s' % tab)
         msg = "Error rendering Jinja template: %s\n\n" % self.error.message
         msg += "Original template source:\n\n%s%s" % (tab, source)
         return msg

--- a/flo/templates/__init__.py
+++ b/flo/templates/__init__.py
@@ -10,7 +10,7 @@ def render_from_string(template_string, **context_dict):
     try:
         template_obj = env.from_string(template_string)
     except jinja2.exceptions.TemplateSyntaxError, error:
-        raise JinjaError(error)
+        raise JinjaError(template_string, error)
     return template_obj.render(**context_dict)
 
 

--- a/flo/templates/__init__.py
+++ b/flo/templates/__init__.py
@@ -2,10 +2,15 @@ import os
 
 import jinja2
 
+from ..exceptions import JinjaError
+
 
 def render_from_string(template_string, **context_dict):
     env = jinja2.Environment()
-    template_obj = env.from_string(template_string)
+    try:
+        template_obj = env.from_string(template_string)
+    except jinja2.exceptions.TemplateSyntaxError, error:
+        raise JinjaError(error)
     return template_obj.render(**context_dict)
 
 

--- a/flo/templates/__init__.py
+++ b/flo/templates/__init__.py
@@ -2,16 +2,19 @@ import os
 
 import jinja2
 
-from ..exceptions import JinjaError
+from ..exceptions import JinjaTemplateError, JinjaRenderError
 
 
 def render_from_string(template_string, **context_dict):
-    env = jinja2.Environment()
+    env = jinja2.Environment(undefined=jinja2.StrictUndefined)
     try:
         template_obj = env.from_string(template_string)
     except jinja2.exceptions.TemplateSyntaxError, error:
-        raise JinjaError(template_string, error)
-    return template_obj.render(**context_dict)
+        raise JinjaTemplateError(template_string, error)
+    try:
+        return template_obj.render(**context_dict)
+    except jinja2.exceptions.UndefinedError, error:
+        raise JinjaRenderError(template_string, error, **context_dict)
 
 
 def render_from_file(template_file, **context_dict):


### PR DESCRIPTION
- [ ] If there is an error when rendering the template, suppress traceback to the terminal. 
- [ ] If a variable doesn't exist in the context when rendering a template, throw an informative error message

This came up when I forgot to close some braces during the demo.
