### PR TITLE
not throwing error when depends doesn't exist

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,8 @@ track version numbers, where backwards incompatible changes
 latest
 ------
 
+* enforce that ``depends`` must exist prior to running any commands (#59)
+
 * more informative error messages (#58)
 
 1.0.0

--- a/docs/yaml_specification.rst
+++ b/docs/yaml_specification.rst
@@ -76,7 +76,9 @@ list <http://en.wikipedia.org/wiki/YAML#Lists>`__ like this:
 These dependencies are what ``flo`` uses to determine if a task is out
 of sync and needs to be re-executed. Importantly, ``flo`` obeys the
 dependencies when it constructs the task graph but always runs in a
-:ref:`deterministic order <deterministic-order>`.
+:ref:`deterministic order <deterministic-order>`. If a specified
+``depends`` does not exist immediately prior to ``flo`` running the
+task, ``flo`` throws an informative error.
 
 .. _yaml-command:
 

--- a/flo/tasks/task.py
+++ b/flo/tasks/task.py
@@ -240,6 +240,14 @@ class Task(resources.base.BaseResource):
         self.graph.logger.info(self.creates_message())
         start_time = time.time()
 
+        # confirm that all depends resources exist on the filesystem
+        if not all(resource.exists() for resource in self.depends_resources):
+            raise CommandLineException(self.depends + (
+                " does not exist just before running this task. "
+                "Double check the `depends` to confirm that these "
+                "dependencies are correct for this task."
+            ))
+
         # run each command for this task
         for command in self.command_list:
             self.graph.logger.info(self.command_message(command))


### PR DESCRIPTION
@frrmack noticed that the following task didn't throw an error when `src/write_hello_world2.py` didn't exist.

``` yaml

---
creates: hello_world.txt
depends: src/write_hello_world2.py # this file doesn't exist
command: python {{depends}} > {{creates}}
```
