### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 development of complex data pipelines. The official documentation for
 this project can be found at http://flo.readthedocs.org.
 
-[![Build Status](https://travis-ci.org/deanmalmgren/flo.svg?branch=master)](https://travis-ci.org/deanmalmgren/flo) [![Version](https://pypip.in/v/flo/badge.png)](https://warehouse.python.org/project/flo/) [![Downloads](https://pypip.in/d/flo/badge.png)](https://warehouse.python.org/project/flo/) 
+[![Build Status](https://travis-ci.org/deanmalmgren/flo.svg?branch=master)](https://travis-ci.org/deanmalmgren/flo) [![Version](https://img.shields.io/pypi/v/flo.svg)](https://warehouse.python.org/project/flo/) [![Downloads](https://img.shields.io/pypi/dm/flo.svg)](https://warehouse.python.org/project/flo/) 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20flo))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `flo`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.